### PR TITLE
Add support for compilation with Waffle

### DIFF
--- a/.github/workflows/mocha-test.yml
+++ b/.github/workflows/mocha-test.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Compile
-        run: yarn compile
+      - name: Compile with Waffle
+        run: yarn compile-waffle
 
       - name: Test
         run: yarn test

--- a/README.md
+++ b/README.md
@@ -22,16 +22,26 @@ $ yarn install
 ```
 
 ## Building
-Build the smart contracts with the following command:
+Build the smart contracts using [Truffle][TRUFFLE] with the following command:
 ```sh
 $ yarn compile
 ```
 
+Alternatively, you can compile them using [Waffle][WAFFLE]:
+```sh
+# Compile for development (optimization off)
+$ yarn compile-waffle
+# Compile for production (optimization on)
+$ yarn compile-waffle:production
+```
+
 ## Testing
-Run test cases with [Waffle](https://getwaffle.io):
+Run test cases with [Waffle][WAFFLE]:
 ```sh
 $ yarn test
 ```
+
+*Note that you must compile the contracts with **Waffle** first as instructed above before running the tests.*
 
 ## Deployment
 You can deploy the smart contracts on currently supported networks
@@ -154,3 +164,4 @@ you will find the created contract addresses in the log/[NETWORK]-deployed.json.
 [TRUFFLE]: <https://www.trufflesuite.com/truffle>
 [OZ]: <https://openzeppelin.com>
 [GAN]: <https://www.trufflesuite.com/ganache>
+[WAFFLE]: <https://getwaffle.io>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "format": "prettier --write .",
     "compile": "truffle compile",
+    "compile-waffle": "waffle waffle-dev.json",
+    "compile-waffle:production": "waffle waffle-prod.json",
     "test": "mocha"
   },
   "author": "",

--- a/waffle-dev.json
+++ b/waffle-dev.json
@@ -1,0 +1,28 @@
+{
+  "compilerType": "solcjs",
+  "compilerVersion": "0.6.12",
+  "outputType": "all",
+  "outputDirectory": "./build/waffle",
+  "compilerOptions": {
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object",
+          "abi",
+          "evm.bytecode.sourceMap",
+          "evm.deployedBytecode.sourceMap",
+          "metadata"
+        ],
+        "": [
+          "ast"
+        ]
+      }
+    },
+    "evmVersion": "istanbul",
+    "optimizer": {
+      "enabled": false,
+      "runs": 200
+    }
+  }
+}

--- a/waffle-prod.json
+++ b/waffle-prod.json
@@ -1,0 +1,28 @@
+{
+  "compilerType": "solcjs",
+  "compilerVersion": "0.6.12",
+  "outputType": "all",
+  "outputDirectory": "./build/waffle",
+  "compilerOptions": {
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object",
+          "abi",
+          "evm.bytecode.sourceMap",
+          "evm.deployedBytecode.sourceMap",
+          "metadata"
+        ],
+        "": [
+          "ast"
+        ]
+      }
+    },
+    "evmVersion": "istanbul",
+    "optimizer": {
+      "enabled": true,
+      "runs": 999999
+    }
+  }
+}


### PR DESCRIPTION
Changes included in this PR:

- adds a Yarn command for compiling with Waffle;
- switches from Truffle to Waffle for compilation in the [test workflow](https://github.com/Linear-finance/linear/actions?query=workflow%3A%22Test+with+Mocha%22).