### PR TITLE
Fix #13: fix failed Truffle test cases

### DIFF
--- a/test/DefaultPrices.js
+++ b/test/DefaultPrices.js
@@ -91,7 +91,7 @@ contract('LnDefaultPrices', async (accounts)=> {
             let timeSent = await currentTime();
 
             // should ignore updates not from oracle
-            assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("CNY")], [ 3,4 ], timeSent, { from: admin} ) );
+            await assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("CNY")], [ 3,4 ], timeSent, { from: admin} ) );
         });
         it('not lusd', async ()=> {
             // new instance of LnDefaultPrices
@@ -99,7 +99,7 @@ contract('LnDefaultPrices', async (accounts)=> {
 
             let timeSent = await currentTime();
 
-            assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("lUSD")], [ 3,4 ], timeSent, { from: oracle} ) );
+            await assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("lUSD")], [ 3,4 ], timeSent, { from: oracle} ) );
         });
         it('not 0', async ()=> {
             // new instance of LnDefaultPrices
@@ -107,7 +107,7 @@ contract('LnDefaultPrices', async (accounts)=> {
 
             let timeSent = await currentTime();
 
-            assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("CNY")], [ 3,0 ], timeSent, { from: oracle} ) );
+            await assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("CNY")], [ 3,0 ], timeSent, { from: oracle} ) );
         });
 
         it('get price and update time', async () => {
@@ -250,7 +250,7 @@ contract('LnDefaultPrices', async (accounts)=> {
             assert.equal( linaPrice.valueOf(), 0 );
 
             // only oracle
-            assertRevert( defaultPrices.deletePrice( toBytes32("CNY"),{ from:admin} ) );
+            await assertRevert( defaultPrices.deletePrice( toBytes32("CNY"),{ from:admin} ) );
             let cnyPrice = await defaultPrices.getPrice( toBytes32("CNY") );    
             assert.equal( cnyPrice.valueOf(), 2 );
         });
@@ -279,11 +279,11 @@ contract('LnDefaultPrices', async (accounts)=> {
             // new instance of LnDefaultPrices
             const defaultPrices = await LnDefaultPrices.new( admin, oracle, [toBytes32("LINA"), toBytes32("CNY")], [ 1,2 ] );
             // should revert, wrong admin
-            assertRevert( defaultPrices.setOracle( admin, {from:oracle}) );
+            await assertRevert( defaultPrices.setOracle( admin, {from:oracle}) );
 
             // shuld revert, wrong oracle
             let timeSent = await currentTime();
-            assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("CNY")], [ 3,4 ], timeSent, { from: oracle } ) );
+            await assertRevert( defaultPrices.updateAll( [toBytes32("LINA"), toBytes32("CNY")], [ 3,4 ], timeSent, { from: admin } ) );
         });
 
 

--- a/test/LnFundVault.js
+++ b/test/LnFundVault.js
@@ -51,7 +51,7 @@ const assertRevert = async (blockOrPromise, reason) => {
 };
 
 
-contract('LnExchangeSystem', async (accounts)=> {
+contract('LnFundVault', async (accounts)=> {
 
     const admin = accounts[0];
     const op1 = accounts[1];
@@ -77,7 +77,7 @@ contract('LnExchangeSystem', async (accounts)=> {
             assert.equal( vaultBalance, v );
 
             // send 1 again
-            assertRevert( web3.eth.sendTransaction(message ) );
+            await assertRevert( web3.eth.sendTransaction(message ) );
 
             // send2
             message = {from: op1, to:vault.address, value: v};
@@ -87,11 +87,11 @@ contract('LnExchangeSystem', async (accounts)=> {
             assert.equal( vaultBalance, v*2 );
 
             // send2 again
-            assertRevert( web3.eth.sendTransaction(message ) );
+            await assertRevert( web3.eth.sendTransaction(message ) );
           
             // send3
             message = {from: op2, to:vault.address, value: v};
-            assertRevert( web3.eth.sendTransaction(message ) );
+            await assertRevert( web3.eth.sendTransaction(message ) );
              
             // claim
             vaultBalance = await web3.eth.getBalance(vault.address);
@@ -123,7 +123,7 @@ contract('LnExchangeSystem', async (accounts)=> {
             assert.equal( vaultBalance, v );
 
             // send 1 again
-            assertRevert( web3.eth.sendTransaction(message ) );
+            await assertRevert( web3.eth.sendTransaction(message ) );
 
             // send2
             message = {from: op1, to:vault.address, value: v};
@@ -133,11 +133,11 @@ contract('LnExchangeSystem', async (accounts)=> {
             assert.equal( vaultBalance, v*2 );
 
             // send2 again
-            assertRevert( web3.eth.sendTransaction(message ) );
+            await assertRevert( web3.eth.sendTransaction(message ) );
           
             // send3
             message = {from: op2, to:vault.address, value: v};
-            assertRevert( web3.eth.sendTransaction(message ) );
+            await assertRevert( web3.eth.sendTransaction(message ) );
              
             // claim
             vaultBalance = await web3.eth.getBalance(vault.address);

--- a/test/TestBuildBurnSystem.js
+++ b/test/TestBuildBurnSystem.js
@@ -49,7 +49,6 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
     it('BuildBurn test', async ()=> {
         const linaBytes32 = toBytes32("lina");
         const ETHBytes32 = toBytes32("ETH");
-        const lusdBytes32 = toBytes32("lUSD");
 
         let InitContracts = await InitComment(ac0);
 
@@ -68,7 +67,7 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
             "Build amount too big, you need more collateral");
         
         // set price
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit(1), toUnit(200), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit(1), toUnit(200)], Math.floor(Date.now()/1000).toString() );
     
         // mint lina
         lina.mint(ac1, toUnit(1000) ); // ac1 mint lina
@@ -261,7 +260,7 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
 
         // price change, debt change, redeem change
         // collateral price down
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit(1), toUnit(100), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit(1), toUnit(100)], Math.floor(Date.now()/1000).toString() );
         // ac1 collateral 750 lina, value 750 usd
         // ac2 collateral 900 lina, value 900 usd
         // ac3 collateral 5 eth, value 500 usd
@@ -289,7 +288,7 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
         assert.equal(v, toUnit(0).toString());
 
         // collateral price down down
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit(0.1), toUnit(10), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit(0.1), toUnit(10)], Math.floor(Date.now()/1000).toString() );
 
         // ac1 collateral 500 lina, value 50 usd
         // ac2 collateral 500 lina, value 50 usd
@@ -318,7 +317,7 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
             "Build amount too big, you need more collateral");
 
         // collateral price up
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit(10), toUnit(1000), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit(10), toUnit(1000)], Math.floor(Date.now()/1000).toString() );
 
         // ac1 collateral 500 lina, value 5000 usd
         // ac2 collateral 500 lina, value 5000 usd
@@ -352,7 +351,7 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
         assert.equal(v, toUnit(3000).toString());
 
         // price down
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit(0.1), toUnit(10), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit(0.1), toUnit(10)], Math.floor(Date.now()/1000).toString() );
 
         v = await kLnCollateralSystem.MaxRedeemableInUsd(ac1);
         assert.equal(v, toUnit(0).toString());
@@ -392,7 +391,6 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
     it('test build burn toTarget', async ()=> {
         const linaBytes32 = toBytes32("lina");
         const ETHBytes32 = toBytes32("ETH");
-        const lusdBytes32 = toBytes32("lUSD");
 
         let InitContracts = await InitComment(ac0);
 
@@ -407,7 +405,7 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
         await kLnCollateralSystem.UpdateTokenInfo( linaBytes32, lina.address, toUnit(1), false);
         
         // set price
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit(1), toUnit(200), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit(1), toUnit(200)], Math.floor(Date.now()/1000).toString() );
         
         // mint lina
         lina.mint(ac1, toUnit(1000) ); // ac1 mint lina
@@ -426,12 +424,12 @@ contract('test LnBuildBurnSystem', async (accounts)=> {
 
         checkDebtBalance(ac1, toUnit(200));
 
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit("0.5"), toUnit(200), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit("0.5"), toUnit(200)], Math.floor(Date.now()/1000).toString() );
         await kLnBuildBurnSystem.BurnAssetToTarget({from:ac1});
 
         checkDebtBalance(ac1, toUnit(100));
 
-        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32, lusdBytes32], [toUnit("1"), toUnit(200), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32, ETHBytes32], [toUnit("1"), toUnit(200)], Math.floor(Date.now()/1000).toString() );
         await exceptionEqual(
             kLnBuildBurnSystem.BurnAssetToTarget({from:ac1}),
             "You maybe want build to target"

--- a/test/TestCollateralSystem.js
+++ b/test/TestCollateralSystem.js
@@ -25,7 +25,6 @@ contract('test LnCollateralSystem', async (accounts)=> {
 
     const linaBytes32 = toBytes32("lina");
     const ETHBytes32 = toBytes32("ETH");
-    const lusdBytes32 = toBytes32("lUSD");
 
     it('collateral and redeem', async ()=> {
         
@@ -212,7 +211,7 @@ contract('test LnCollateralSystem', async (accounts)=> {
         let lUSD = InitContracts.lUSD;
 
         await kLnCollateralSystem.UpdateTokenInfo( linaBytes32, lina.address, toUnit(1), false);
-        await kLnChainLinkPrices.updateAll([linaBytes32, lusdBytes32], [toUnit(1), toUnit(1)], Math.floor(Date.now()/1000).toString() );
+        await kLnChainLinkPrices.updateAll([linaBytes32], [toUnit(1)], Math.floor(Date.now()/1000).toString() );
 
         let v = await kLnCollateralSystem.GetSystemTotalCollateralInUsd();
         assert.equal(v.valueOf(), 0);

--- a/test/common.js
+++ b/test/common.js
@@ -101,6 +101,7 @@ async function InitComment(admin) {
     registContract("LnBuildBurnSystem", kLnBuildBurnSystem);
     registContract("LnFeeSystem", kLnFeeSystem);
     registContract("LnRewardLocker", kLnRewardLocker);
+    registContract("LnExchangeSystem", kLnExchangeSystem);
   
     await kLnAssetSystem.updateAll(contractNames, contractAddrs);
 


### PR DESCRIPTION
Fixes #13.

This PR fixes test run failures mentioned in #13. Now `yarn truffle test` should be successful.

As a side note though, one of the failed test cases (`Contract: LnDefaultPrices/setOracle/only admin`) was exceptionally hard to debug, as it forgot to `await` the `Promise` returned by a call to `assertRevert()`, resulting in the failure to be **reported under another test case** that's actually correct (`Contract: LnExchangeSystem/exchange`).

So please make sure to remember to await `Promise`s in test cases.