### PR TITLE
Fix event naming convention

### DIFF
--- a/contracts/LnAddressCache.sol
+++ b/contracts/LnAddressCache.sol
@@ -16,7 +16,7 @@ contract LnAddressStorage is LnAdmin {
 
         for (uint i = 0; i < names.length; i++) {
             mAddrs[names[i]] = destinations[i];
-            emit updateStorageAddress( names[i], destinations[i] );
+            emit StorageAddressUpdated( names[i], destinations[i] );
         }
     }
 
@@ -24,7 +24,7 @@ contract LnAddressStorage is LnAdmin {
         require( name != "", "name can not be empty");
         require( dest != address(0), "address cannot be 0");
         mAddrs[name] = dest;
-        emit updateStorageAddress( name, dest );
+        emit StorageAddressUpdated( name, dest );
     }
 
     function getAddress(bytes32 name) external view returns (address) {
@@ -36,14 +36,14 @@ contract LnAddressStorage is LnAdmin {
         require(_foundAddress != address(0), reason);
         return _foundAddress;
     }
-    event updateStorageAddress( bytes32 name, address addr );
+    event StorageAddressUpdated( bytes32 name, address addr );
 }
 
 
 interface LnAddressCache  {
     function updateAddressCache( LnAddressStorage _addressStorage )  external ;
 
-    event   updateCachedAddress( bytes32 name, address addr );
+    event   CachedAddressUpdated( bytes32 name, address addr );
 }
 
 contract testAddressCache  is LnAddressCache, LnAdmin {
@@ -57,8 +57,8 @@ contract testAddressCache  is LnAddressCache, LnAdmin {
     {
         addr1 = LnAddressStorage(_addressStorage).getAddressWithRequire("a", "");
         addr2 = LnAddressStorage(_addressStorage).getAddressWithRequire("b", "" );
-        emit updateCachedAddress( "a", addr1 );
-        emit updateCachedAddress( "b", addr2 );
+        emit CachedAddressUpdated( "a", addr1 );
+        emit CachedAddressUpdated( "b", addr2 );
     }
 
 }

--- a/contracts/LnAdmin.sol
+++ b/contracts/LnAdmin.sol
@@ -14,7 +14,7 @@ contract LnAdmin {
     function setCandidate(address _candidate) external onlyAdmin {
         address old = candidate;
         candidate = _candidate;
-        emit candidateChanged( old, candidate);
+        emit CandidateChanged( old, candidate);
     }
 
     function becomeAdmin( ) external {
@@ -29,7 +29,7 @@ contract LnAdmin {
         _;
     }
 
-    event candidateChanged(address oldCandidate, address newCandidate );
+    event CandidateChanged(address oldCandidate, address newCandidate );
     event AdminChanged(address oldAdmin, address newAdmin);
 }
 

--- a/contracts/LnAssetUpgradeable.sol
+++ b/contracts/LnAssetUpgradeable.sol
@@ -46,7 +46,7 @@ contract LnAssetUpgradeable is ERC20Upgradeable, LnAdminUpgradeable, IAsset, LnA
             _addressStorage.getAddressWithRequire("LnAccessControl", "LnAccessControl address not valid")
         );
 
-        emit updateCachedAddress("LnAccessControl", address(accessCtrl));
+        emit CachedAddressUpdated("LnAccessControl", address(accessCtrl));
     }
 
     function mint(address account, uint256 amount) external onlyIssueAssetRole(msg.sender) {

--- a/contracts/LnBuildBurnSystem.sol
+++ b/contracts/LnBuildBurnSystem.sol
@@ -52,11 +52,11 @@ contract LnBuildBurnSystem is LnAdmin, Pausable, LnAddressCache {
         collaterSys = LnCollateralSystem( collateralAddress );
         mConfig =        LnConfig( _addressStorage.getAddressWithRequire( "LnConfig",     "LnConfig address not valid" ) );
 
-        emit updateCachedAddress( "LnPrices",           address(priceGetter) );
-        emit updateCachedAddress( "LnDebtSystem",       address(debtSystem) );
-        emit updateCachedAddress( "LnAssetSystem",      address(assetSys) );
-        emit updateCachedAddress( "LnCollateralSystem", address(collaterSys) );
-        emit updateCachedAddress( "LnConfig",           address(mConfig) );
+        emit CachedAddressUpdated( "LnPrices",           address(priceGetter) );
+        emit CachedAddressUpdated( "LnDebtSystem",       address(debtSystem) );
+        emit CachedAddressUpdated( "LnAssetSystem",      address(assetSys) );
+        emit CachedAddressUpdated( "LnCollateralSystem", address(collaterSys) );
+        emit CachedAddressUpdated( "LnConfig",           address(mConfig) );
     }
 
     function SetLusdTokenAddress(address _address) public onlyAdmin {

--- a/contracts/LnCollateralSystem.sol
+++ b/contracts/LnCollateralSystem.sol
@@ -73,11 +73,11 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         mConfig =         LnConfig(         _addressStorage.getAddressWithRequire( "LnConfig",          "LnConfig address not valid" ) );
         mRewardLocker =   LnRewardLocker(   _addressStorage.getAddressWithRequire( "LnRewardLocker",    "LnRewardLocker address not valid" ));
 
-        emit updateCachedAddress( "LnPrices",          address(priceGetter) );
-        emit updateCachedAddress( "LnDebtSystem",      address(debtSystem) );
-        emit updateCachedAddress( "LnBuildBurnSystem", address(buildBurnSystem) );
-        emit updateCachedAddress( "LnConfig",          address(mConfig) );
-        emit updateCachedAddress( "LnRewardLocker",    address(mRewardLocker) );
+        emit CachedAddressUpdated( "LnPrices",          address(priceGetter) );
+        emit CachedAddressUpdated( "LnDebtSystem",      address(debtSystem) );
+        emit CachedAddressUpdated( "LnBuildBurnSystem", address(buildBurnSystem) );
+        emit CachedAddressUpdated( "LnConfig",          address(mConfig) );
+        emit CachedAddressUpdated( "LnRewardLocker",    address(mRewardLocker) );
     }
 
     function updateTokenInfo(bytes32 _currency, address _tokenAddr, uint256 _minCollateral, bool _close) private returns (bool) {

--- a/contracts/LnDebtSystem.sol
+++ b/contracts/LnDebtSystem.sol
@@ -53,9 +53,9 @@ contract LnDebtSystem is LnAdminUpgradeable, LnAddressCache {
         assetSys =   LnAssetSystem(  _addressStorage.getAddressWithRequire( "LnAssetSystem",   "LnAssetSystem address not valid" ));
         feeSystem = LnFeeSystem( _addressStorage.getAddressWithRequire( "LnFeeSystem",   "LnFeeSystem address not valid" ));
 
-        emit updateCachedAddress( "LnAccessControl", address(accessCtrl) );
-        emit updateCachedAddress( "LnAssetSystem",   address(assetSys) );
-        emit updateCachedAddress( "LnFeeSystem",   address(feeSystem) );
+        emit CachedAddressUpdated( "LnAccessControl", address(accessCtrl) );
+        emit CachedAddressUpdated( "LnAssetSystem",   address(assetSys) );
+        emit CachedAddressUpdated( "LnFeeSystem",   address(feeSystem) );
     }
     
     // -----------------------------------------------

--- a/contracts/LnErc20Bridge.sol
+++ b/contracts/LnErc20Bridge.sol
@@ -46,7 +46,7 @@ contract LnErc20Bridge is LnAdmin {
         freezeTxLog[_account][_txId] = _freezeTx;
         pendingProcess[_account].push(_txId);
 
-        emit setFreezeTxLog(_account, _txId, _amount, _timestamp);
+        emit SetFreezeTxLog(_account, _txId, _amount, _timestamp);
         return true;
     }
 
@@ -62,7 +62,7 @@ contract LnErc20Bridge is LnAdmin {
 
         erc20.transferFrom(user, frozenHolder, _amount);
 
-        emit freezeLog(user, erc20.symbol(), _amount);
+        emit FreezeLog(user, erc20.symbol(), _amount);
         return true;
     }    
 
@@ -82,7 +82,7 @@ contract LnErc20Bridge is LnAdmin {
             }
         }
 
-        emit unfreezeLog(user, erc20.symbol(), amount);
+        emit UnfreezeLog(user, erc20.symbol(), amount);
         return true;
     }  
 
@@ -94,9 +94,9 @@ contract LnErc20Bridge is LnAdmin {
         return pendingProcess[_account];
     }
 
-    event freezeLog(address user, string _currency, uint256 _amount);
-    event unfreezeLog(address user, string _currency, uint256 _amount);
-    event setFreezeTxLog(address _account, string _txId, uint _amount, uint _timestamp);
+    event FreezeLog(address user, string _currency, uint256 _amount);
+    event UnfreezeLog(address user, string _currency, uint256 _amount);
+    event SetFreezeTxLog(address _account, string _txId, uint _amount, uint _timestamp);
 
 
 

--- a/contracts/LnExchangeSystem.sol
+++ b/contracts/LnExchangeSystem.sol
@@ -36,10 +36,10 @@ contract LnExchangeSystem is LnAddressCache, LnAdmin {
         mFeeSys = LnFeeSystem(_addressStorage.getAddressWithRequire( FEE_SYS_KEY,"" ));
 
 
-        emit updateCachedAddress( ASSETS_KEY, address(mAssets) );
-        emit updateCachedAddress( PRICES_KEY, address(mPrices) );
-        emit updateCachedAddress( CONFIG_KEY, address(mConfig) );
-        emit updateCachedAddress( FEE_SYS_KEY, address(mFeeSys) );
+        emit CachedAddressUpdated( ASSETS_KEY, address(mAssets) );
+        emit CachedAddressUpdated( PRICES_KEY, address(mPrices) );
+        emit CachedAddressUpdated( CONFIG_KEY, address(mConfig) );
+        emit CachedAddressUpdated( FEE_SYS_KEY, address(mFeeSys) );
     }
 
 
@@ -71,7 +71,7 @@ contract LnExchangeSystem is LnAddressCache, LnAdmin {
 
         dest.mint( destAddr, destRecived );
 
-        emit exchangeAsset( fromAddr, sourceKey, sourceAmount, destAddr, destKey, destRecived, feeUsd );
+        emit ExchangeAsset( fromAddr, sourceKey, sourceAmount, destAddr, destKey, destRecived, feeUsd );
     }
 
     function _addExchangeFee( uint feeUsd ) internal
@@ -81,6 +81,6 @@ contract LnExchangeSystem is LnAddressCache, LnAdmin {
         mFeeSys.addExchangeFee( feeUsd );
     }
     
-    event exchangeAsset( address fromAddr, bytes32 sourceKey, uint sourceAmount, address destAddr, bytes32 destKey,  uint destRecived, uint fee );
+    event ExchangeAsset( address fromAddr, bytes32 sourceKey, uint sourceAmount, address destAddr, bytes32 destKey,  uint destRecived, uint fee );
 }
 

--- a/contracts/LnFeeSystem.sol
+++ b/contracts/LnFeeSystem.sol
@@ -124,11 +124,11 @@ contract LnFeeSystem is LnAdminUpgradeable, LnAddressCache {
         // as Init func. record LnExchangeSystem address
         exchangeSystemAddress = _addressStorage.getAddressWithRequire( "LnExchangeSystem","LnExchangeSystem address not valid" );
 
-        emit updateCachedAddress( "LnDebtSystem", address(debtSystem) );
-        emit updateCachedAddress( "LnCollateralSystem", address(collateralSystem) );
-        emit updateCachedAddress( "LnRewardLocker", address(rewardLocker) );
-        emit updateCachedAddress( "LnAssetSystem", address(mAssets) );
-        emit updateCachedAddress( "LnExchangeSystem", address(exchangeSystemAddress) );
+        emit CachedAddressUpdated( "LnDebtSystem", address(debtSystem) );
+        emit CachedAddressUpdated( "LnCollateralSystem", address(collateralSystem) );
+        emit CachedAddressUpdated( "LnRewardLocker", address(rewardLocker) );
+        emit CachedAddressUpdated( "LnAssetSystem", address(mAssets) );
+        emit CachedAddressUpdated( "LnExchangeSystem", address(exchangeSystemAddress) );
      }
 
     function switchPeriod() public {


### PR DESCRIPTION
Pascal casing naming convention should be used for events. This PR fixes event names that don't follow such convention.