### PR TITLE
Add LnRewardSystem for weekly reward distribution

### DIFF
--- a/.github/workflows/hardhat-test.yml
+++ b/.github/workflows/hardhat-test.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn install
 
       - name: Compile with Hardhat
-        run: yarn compile-hardhat
+        run: yarn compile
 
-      - name: Test
+      - name: Test with Hardhat
         run: yarn test

--- a/README.md
+++ b/README.md
@@ -22,22 +22,9 @@ $ yarn install
 ```
 
 ## Building
-Build the smart contracts using [Truffle][TRUFFLE] with the following command:
+Build the smart contracts using [Hardhat][HARDHAT] with the following command:
 ```sh
 $ yarn compile
-```
-
-Alternatively, you can compile them using [Waffle][WAFFLE]:
-```sh
-# Compile for development (optimization off)
-$ yarn compile-waffle
-# Compile for production (optimization on)
-$ yarn compile-waffle:production
-```
-
-[Hardhat][HARDHAT] is also supported for compilation:
-```sh
-$ yarn compile-hardhat
 ```
 
 ## Testing
@@ -164,8 +151,5 @@ you will find the created contract addresses in the log/[NETWORK]-deployed.json.
 ```
 
 [NODE]: <https://nodejs.org>
-[TRUFFLE]: <https://www.trufflesuite.com/truffle>
-[OZ]: <https://openzeppelin.com>
 [GAN]: <https://www.trufflesuite.com/ganache>
-[WAFFLE]: <https://getwaffle.io>
 [HARDHAT]: <https://hardhat.org>

--- a/contracts/LnRewardSystem.sol
+++ b/contracts/LnRewardSystem.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+import "./interfaces/ILnCollateralSystem.sol";
+import "./interfaces/ILnRewardLocker.sol";
+import "./upgradeable/LnAdminUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+/**
+ * @title LnRewardSystem
+ *
+ * @dev A contract for distributing staking rewards and exchange fees based on
+ * amounts calculated and signed off-chain.
+ *
+ * This contract only performs basic signature validation and re-entrance prevention
+ * to minimize the cost of claming rewards.
+ *
+ * Period ID starts from 1, not zero.
+ */
+contract LnRewardSystem is LnAdminUpgradeable {
+    using SafeMathUpgradeable for uint256;
+
+    event RewardSignerChanged(address oldSigner, address newSigner);
+    event RewardClaimed(address recipient, uint256 periodId, uint256 stakingReward, uint256 feeReward);
+
+    uint256 public firstPeriodStartTime;
+    address public rewardSigner;
+    mapping(address => uint256) userLastClaimPeriodIds;
+
+    IERC20Upgradeable public lusd;
+    ILnCollateralSystem public collateralSystem;
+    ILnRewardLocker public rewardLocker;
+
+    bytes32 public DOMAIN_SEPARATOR; // For EIP-712
+
+    /* EIP-712 type hashes */
+    bytes32 public constant REWARD_TYPEHASH =
+        keccak256("Reward(uint256 periodId,address recipient,uint256 stakingReward,uint256 feeReward)");
+
+    uint256 public constant PERIOD_LENGTH = 1 weeks;
+    uint256 public constant CLAIM_WINDOW_PERIOD_COUNT = 2;
+    uint256 public constant STAKING_REWARD_LOCK_PERIOD = 52 weeks;
+
+    function getCurrentPeriodId() public view returns (uint256) {
+        require(block.timestamp >= firstPeriodStartTime, "LnRewardSystem: first period not started");
+        return (block.timestamp - firstPeriodStartTime) / PERIOD_LENGTH + 1; // No SafeMath needed
+    }
+
+    function getPeriodStartTime(uint256 periodId) public view returns (uint256) {
+        require(periodId > 0, "LnRewardSystem: period ID must be positive");
+        return firstPeriodStartTime.add(periodId.sub(1).mul(PERIOD_LENGTH));
+    }
+
+    function getPeriodEndTime(uint256 periodId) public view returns (uint256) {
+        require(periodId > 0, "LnRewardSystem: period ID must be positive");
+        return firstPeriodStartTime.add(periodId.mul(PERIOD_LENGTH));
+    }
+
+    function __LnRewardSystem_init(
+        uint256 _firstPeriodStartTime,
+        address _rewardSigner,
+        address _lusdAddress,
+        address _collateralSystemAddress,
+        address _rewardLockerAddress,
+        address _admin
+    ) public initializer {
+        __LnAdminUpgradeable_init(_admin);
+
+        require(block.timestamp < _firstPeriodStartTime + PERIOD_LENGTH, "LnRewardSystem: first period already ended");
+        firstPeriodStartTime = _firstPeriodStartTime;
+
+        _setRewardSigner(_rewardSigner);
+
+        require(
+            _lusdAddress != address(0) && _collateralSystemAddress != address(0) && _rewardLockerAddress != address(0),
+            "LnRewardSystem: zero address"
+        );
+        lusd = IERC20Upgradeable(_lusdAddress);
+        collateralSystem = ILnCollateralSystem(_collateralSystemAddress);
+        rewardLocker = ILnRewardLocker(_rewardLockerAddress);
+
+        // While we could in-theory calculate the EIP-712 domain separator off-chain, doing
+        // it on-chain simplifies deployment and the cost here is one-off and acceptable.
+        uint256 chainId;
+        assembly {
+            chainId := chainid()
+        }
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes("Linear")),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)
+            )
+        );
+    }
+
+    function setRewardSigner(address _rewardSigner) external onlyAdmin {
+        _setRewardSigner(_rewardSigner);
+    }
+
+    function claimReward(
+        uint256 periodId,
+        uint256 stakingReward,
+        uint256 feeReward,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        _claimReward(periodId, msg.sender, stakingReward, feeReward, v, r, s);
+    }
+
+    function claimRewardFor(
+        uint256 periodId,
+        address recipient,
+        uint256 stakingReward,
+        uint256 feeReward,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        _claimReward(periodId, recipient, stakingReward, feeReward, v, r, s);
+    }
+
+    function _setRewardSigner(address _rewardSigner) private {
+        require(_rewardSigner != address(0), "LnRewardSystem: zero address");
+        require(_rewardSigner != rewardSigner, "LnRewardSystem: signer not changed");
+
+        address oldSigner = rewardSigner;
+        rewardSigner = _rewardSigner;
+
+        emit RewardSignerChanged(oldSigner, rewardSigner);
+    }
+
+    function _claimReward(
+        uint256 periodId,
+        address recipient,
+        uint256 stakingReward,
+        uint256 feeReward,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) private {
+        require(periodId > 0, "LnRewardSystem: period ID must be positive");
+        require(stakingReward > 0 || feeReward > 0, "LnRewardSystem: nothing to claim");
+
+        // Check if the target period is in the claiming window
+        uint256 currentPeriodId = getCurrentPeriodId();
+        require(periodId < currentPeriodId, "LnRewardSystem: period not ended");
+        require(
+            currentPeriodId <= CLAIM_WINDOW_PERIOD_COUNT || periodId >= currentPeriodId - CLAIM_WINDOW_PERIOD_COUNT,
+            "LnRewardSystem: reward expired"
+        );
+
+        // Re-entrance prevention
+        require(userLastClaimPeriodIds[recipient] < periodId, "LnRewardSystem: reward already claimed");
+        userLastClaimPeriodIds[recipient] = periodId;
+
+        // Users can only claim rewards if target ratio is satisfied
+        require(collateralSystem.IsSatisfyTargetRatio(recipient), "LnRewardSystem: below target ratio");
+
+        // Verify EIP-712 signature
+        bytes32 digest =
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR,
+                    keccak256(abi.encode(REWARD_TYPEHASH, periodId, recipient, stakingReward, feeReward))
+                )
+            );
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(recoveredAddress == rewardSigner, "LnRewardSystem: invalid signature");
+
+        if (stakingReward > 0) {
+            rewardLocker.appendReward(
+                recipient,
+                stakingReward,
+                uint64(getPeriodEndTime(periodId) + STAKING_REWARD_LOCK_PERIOD)
+            );
+        }
+
+        if (feeReward > 0) {
+            lusd.transfer(recipient, feeReward);
+        }
+
+        emit RewardClaimed(recipient, periodId, stakingReward, feeReward);
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[43] private __gap;
+}

--- a/contracts/interfaces/ILnCollateralSystem.sol
+++ b/contracts/interfaces/ILnCollateralSystem.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+interface ILnCollateralSystem {
+    function IsSatisfyTargetRatio(address _user) external view returns (bool);
+}

--- a/contracts/interfaces/ILnRewardLocker.sol
+++ b/contracts/interfaces/ILnRewardLocker.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+interface ILnRewardLocker {
+    function appendReward(
+        address _user,
+        uint256 _amount,
+        uint64 _lockTo
+    ) external;
+}

--- a/contracts/mock/MockLnRewardLocker.sol
+++ b/contracts/mock/MockLnRewardLocker.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+import "../interfaces/ILnRewardLocker.sol";
+
+/**
+ * @title MockLnRewardLocker
+ *
+ * @dev A mock LnRewardLocker contract for testing. We wouldn't need this
+ * contract if Hardhat supported Waffle's `calledOnContractWith` on mocks.
+ */
+contract MockLnRewardLocker is ILnRewardLocker {
+    struct AppendRewardArgs {
+        address _user;
+        uint256 _amount;
+        uint64 _lockTo;
+    }
+
+    AppendRewardArgs[] appendRewardCalls;
+
+    function lastAppendRewardCall()
+        public
+        view
+        returns (
+            address _user,
+            uint256 _amount,
+            uint64 _lockTo
+        )
+    {
+        AppendRewardArgs memory args = appendRewardCalls[appendRewardCalls.length - 1];
+        return (args._user, args._amount, args._lockTo);
+    }
+
+    function appendReward(
+        address _user,
+        uint256 _amount,
+        uint64 _lockTo
+    ) external override {
+        appendRewardCalls.push(AppendRewardArgs({_user: _user, _amount: _amount, _lockTo: _lockTo}));
+    }
+}

--- a/contracts/upgradeable/LnAdminUpgradeable.sol
+++ b/contracts/upgradeable/LnAdminUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.12;
+pragma solidity >=0.6.12 <0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,14 +3,28 @@ import "@openzeppelin/hardhat-upgrades";
 
 export default {
   solidity: {
-    version: "0.6.12",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 999999,
+    compilers: [
+      {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 999999,
+          },
+          evmVersion: "istanbul",
+        },
       },
-      evmVersion: "istanbul",
-    },
+      {
+        version: "0.7.6",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 999999,
+          },
+          evmVersion: "istanbul",
+        },
+      },
+    ],
   },
   paths: {
     tests: "./tests",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "main": "truffle-config.js",
   "scripts": {
     "format": "prettier --write .",
-    "compile": "truffle compile",
-    "compile-waffle": "waffle waffle-dev.json",
-    "compile-waffle:production": "waffle waffle-prod.json",
-    "compile-hardhat": "hardhat compile",
+    "compile": "hardhat compile",
     "test": "hardhat test"
   },
   "author": "",

--- a/tests/LnRewardSystem.spec.ts
+++ b/tests/LnRewardSystem.spec.ts
@@ -1,0 +1,321 @@
+import { ethers, waffle } from "hardhat";
+import { expect, use } from "chai";
+import { BigNumber, Contract, Signature, Wallet } from "ethers";
+import { splitSignature } from "ethers/lib/utils";
+import { MockContract } from "ethereum-waffle";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { DateTime, Duration } from "luxon";
+import { expandTo18Decimals } from "./utilities";
+import {
+  getBlockDateTime,
+  setNextBlockTimestamp,
+} from "./utilities/timeTravel";
+
+import ILnCollateralSystem from "../artifacts/contracts/interfaces/ILnCollateralSystem.sol/ILnCollateralSystem.json";
+
+use(waffle.solidity);
+
+describe("LnRewardSystem", function () {
+  let deployer: SignerWithAddress,
+    admin: SignerWithAddress,
+    alice: SignerWithAddress,
+    bob: SignerWithAddress,
+    rewardSigner: Wallet;
+
+  let lusd: Contract,
+    lnCollateralSystem: MockContract,
+    lnRewardLocker: Contract,
+    lnRewardSystem: Contract;
+
+  let aliceSignaturePeriod1: Signature;
+
+  let firstPeriodStartTime: DateTime;
+  const periodDuration: Duration = Duration.fromObject({ weeks: 1 });
+  const stakingRewardLockTime: Duration = Duration.fromObject({ weeks: 52 });
+
+  const getPeriodEndTime = (periodId: number): DateTime => {
+    let endTime = firstPeriodStartTime;
+    for (let ind = 0; ind < periodId; ind++) {
+      endTime = endTime.plus(periodDuration);
+    }
+    return endTime;
+  };
+
+  const createSignature = async (
+    signer: Wallet,
+    periodId: BigNumber,
+    recipient: string,
+    stakingReward: BigNumber,
+    feeReward: BigNumber
+  ): Promise<Signature> => {
+    const domain = {
+      name: "Linear",
+      version: "1",
+      chainId: (await ethers.provider.getNetwork()).chainId,
+      verifyingContract: lnRewardSystem.address,
+    };
+
+    const types = {
+      Reward: [
+        { name: "periodId", type: "uint256" },
+        { name: "recipient", type: "address" },
+        { name: "stakingReward", type: "uint256" },
+        { name: "feeReward", type: "uint256" },
+      ],
+    };
+
+    const value = {
+      periodId,
+      recipient,
+      stakingReward,
+      feeReward,
+    };
+
+    const signatureHex = await signer._signTypedData(domain, types, value);
+
+    return splitSignature(signatureHex);
+  };
+
+  beforeEach(async function () {
+    [deployer, admin, alice, bob] = await ethers.getSigners();
+    rewardSigner = Wallet.createRandom();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const MockLnRewardLocker = await ethers.getContractFactory(
+      "MockLnRewardLocker"
+    );
+    const LnRewardSystem = await ethers.getContractFactory("LnRewardSystem");
+
+    firstPeriodStartTime = (await getBlockDateTime(ethers.provider)).plus({
+      days: 1,
+    });
+
+    lusd = await MockERC20.deploy(
+      "lUSD", // _name
+      "lUSD" // _symbol
+    );
+
+    lnCollateralSystem = await waffle.deployMockContract(
+      deployer,
+      ILnCollateralSystem.abi
+    );
+    await lnCollateralSystem.mock.IsSatisfyTargetRatio.returns(true);
+
+    lnRewardLocker = await MockLnRewardLocker.deploy();
+
+    lnRewardSystem = await LnRewardSystem.deploy();
+    await lnRewardSystem.connect(deployer).__LnRewardSystem_init(
+      firstPeriodStartTime.toSeconds(), // _firstPeriodStartTime
+      rewardSigner.address, // _rewardSigner
+      lusd.address, // _lusdAddress
+      lnCollateralSystem.address, // _collateralSystemAddress
+      lnRewardLocker.address, // _rewardLockerAddress
+      admin.address // _admin
+    );
+
+    // LnRewardSystem holds 1,000,000 lUSD to start
+    await lusd
+      .connect(deployer)
+      .mint(lnRewardSystem.address, expandTo18Decimals(1_000_000));
+
+    // Period 1, 100 staking reward, 100 fee reward
+    aliceSignaturePeriod1 = await createSignature(
+      rewardSigner,
+      BigNumber.from(1),
+      alice.address,
+      expandTo18Decimals(100),
+      expandTo18Decimals(200)
+    );
+  });
+
+  it("only admin can change signer", async () => {
+    expect(await lnRewardSystem.rewardSigner()).to.equal(rewardSigner.address);
+
+    await expect(
+      lnRewardSystem.connect(alice).setRewardSigner(alice.address)
+    ).to.revertedWith(
+      "LnAdminUpgradeable: only the contract admin can perform this action"
+    );
+
+    await lnRewardSystem.connect(admin).setRewardSigner(alice.address);
+
+    expect(await lnRewardSystem.rewardSigner()).to.equal(alice.address);
+  });
+
+  it("can claim reward with valid signature", async () => {
+    await setNextBlockTimestamp(ethers.provider, getPeriodEndTime(1));
+
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    )
+      .to.emit(lnRewardSystem, "RewardClaimed")
+      .withArgs(
+        alice.address, // recipient
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200) // feeReward
+      )
+      .to.emit(lusd, "Transfer")
+      .withArgs(lnRewardSystem.address, alice.address, expandTo18Decimals(200));
+
+    // Assert staking reward
+    const lastAppendRewardCall = await lnRewardLocker.lastAppendRewardCall();
+    expect(lastAppendRewardCall._user).to.equal(alice.address);
+    expect(lastAppendRewardCall._amount).to.equal(expandTo18Decimals(100));
+    expect(lastAppendRewardCall._lockTo).to.equal(
+      getPeriodEndTime(1).plus(stakingRewardLockTime).toSeconds()
+    );
+
+    // Assert fee reward
+    expect(await lusd.balanceOf(lnRewardSystem.address)).to.equal(
+      expandTo18Decimals(999_800)
+    );
+    expect(await lusd.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(200)
+    );
+  });
+
+  it("cannot claim reward with invalid signature", async () => {
+    // Signature for the same struct generated by a random signer
+    const fakeSigner = Wallet.createRandom();
+    const fakeSignature = await createSignature(
+      fakeSigner,
+      BigNumber.from(1),
+      alice.address,
+      expandTo18Decimals(100),
+      expandTo18Decimals(200)
+    );
+
+    await setNextBlockTimestamp(ethers.provider, getPeriodEndTime(2));
+
+    // Wrong period id
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        2, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: invalid signature");
+
+    // Wrong staking reward
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(200), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: invalid signature");
+
+    // Wrong fee reward
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(300), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: invalid signature");
+
+    // Wrong signer
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        fakeSignature.v, // v
+        fakeSignature.r, // r
+        fakeSignature.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: invalid signature");
+  });
+
+  it("cannot claim reward before period ends", async () => {
+    await setNextBlockTimestamp(
+      ethers.provider,
+      getPeriodEndTime(1).minus({ seconds: 1 })
+    );
+
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: period not ended");
+  });
+
+  it("cannot claim reward after expiration", async () => {
+    await setNextBlockTimestamp(ethers.provider, getPeriodEndTime(3));
+
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: reward expired");
+  });
+
+  it("cannot claim reward if target ratio is not met", async () => {
+    await setNextBlockTimestamp(ethers.provider, getPeriodEndTime(1));
+
+    // This is a unit test so we just set it to false directly
+    await lnCollateralSystem.mock.IsSatisfyTargetRatio.returns(false);
+
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: below target ratio");
+  });
+
+  it("cannot claim reward multiple times", async () => {
+    await setNextBlockTimestamp(ethers.provider, getPeriodEndTime(1));
+
+    await lnRewardSystem.connect(alice).claimReward(
+      1, // periodId
+      expandTo18Decimals(100), // stakingReward
+      expandTo18Decimals(200), // feeReward
+      aliceSignaturePeriod1.v, // v
+      aliceSignaturePeriod1.r, // r
+      aliceSignaturePeriod1.s // s
+    );
+
+    await expect(
+      lnRewardSystem.connect(alice).claimReward(
+        1, // periodId
+        expandTo18Decimals(100), // stakingReward
+        expandTo18Decimals(200), // feeReward
+        aliceSignaturePeriod1.v, // v
+        aliceSignaturePeriod1.r, // r
+        aliceSignaturePeriod1.s // s
+      )
+    ).to.revertedWith("LnRewardSystem: reward already claimed");
+  });
+});


### PR DESCRIPTION
This PR:

- adds a new contract `LnRewardSystem` and relevant test cases;
- adds support for mixing compiler versions in different contracts so that we're not stuck with `0.6.12` forever;
- removes Truffle and Waffle compilation from NPM scripts as they don't support multiple compiler versions.