### PR TITLE
Fix property incorrectly set as private in LnRewardSystem

### DIFF
--- a/contracts/LnRewardSystem.sol
+++ b/contracts/LnRewardSystem.sol
@@ -26,7 +26,7 @@ contract LnRewardSystem is LnAdminUpgradeable {
 
     uint256 public firstPeriodStartTime;
     address public rewardSigner;
-    mapping(address => uint256) userLastClaimPeriodIds;
+    mapping(address => uint256) public userLastClaimPeriodIds;
 
     IERC20Upgradeable public lusd;
     ILnCollateralSystem public collateralSystem;


### PR DESCRIPTION
This PR fixes the visibility of the property `userLastClaimPeriodIds`, was incorrectly set as private.