### PR TITLE
Add LnErc20Bridge for swapping ERC20 tokens among EVM chains

### DIFF
--- a/contracts/LnErc20Bridge.sol
+++ b/contracts/LnErc20Bridge.sol
@@ -1,103 +1,332 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.12;
-pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.6;
 
-import "./IERC20.sol";
-import "./LnAdmin.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
-import "./SafeDecimalMath.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
+import "./interfaces/IMintBurnToken.sol";
+import "./upgradeable/LnAdminUpgradeable.sol";
 
+/**
+ * @title LnErc20Bridge
+ *
+ * @dev An upgradeable contract for moving ERC20 tokens across blockchains. An
+ * off-chain relayer is responsible for notifying destination chains of the
+ * transactions. The relayer can be set to a multi-signature secured account for
+ * enhanced security and decentralization.
+ *
+ * @dev The relayer should wait for finality on the source chain before relaying the transaction
+ * to the destination. Otherwise a double-spending attack is possible.
+ *
+ * @dev The bridge can operate in two different modes for each token: transfer mode and mint/burn
+ * mode.
+ *
+ * @dev Note that transaction hashes shall NOT be used for re-entrance prevention as doing
+ * so will result in false negatives when multiple transfers are made in a single
+ * transaction (with the use of contracts).
+ *
+ * @dev Chain IDs in this contract currently refer to the ones introduced in EIP-155. However,
+ * a list of custom IDs might be used instead when non-EVM compatible chains are added.
+ */
+contract LnErc20Bridge is LnAdminUpgradeable {
+    /**
+     * @dev Emits when a deposit is made.
+     *
+     * @dev Addresses are represented with bytes32 to maximize compatibility with
+     * non-Ethereum-compatible blockchains.
+     *
+     * @param srcChainId Chain ID of the source blockchain (current chain)
+     * @param destChainId Chain ID of the destination blockchain
+     * @param depositId Unique ID of the deposit on the current chain
+     * @param depositor Address of the account on the current chain that made the deposit
+     * @param withdrawer Address of the account on the destination chain that's allowed to withdraw
+     * @param currency A bytes32-encoded universal currency key
+     * @param amount Amount of tokens being deposited
+     * @param forcedWithdrawalAllowed Whether the depositor allowed the amount to be forcibly pushed
+     * to withdrawer's address.
+     */
+    event TokenDeposited(
+        uint256 srcChainId,
+        uint256 destChainId,
+        uint256 depositId,
+        bytes32 depositor,
+        bytes32 withdrawer,
+        bytes32 currency,
+        uint256 amount,
+        bool forcedWithdrawalAllowed
+    );
+    event DepositRelayed(
+        uint256 srcChainId,
+        uint256 destChainId,
+        uint256 depositId,
+        bytes32 depositor,
+        bytes32 withdrawer,
+        bytes32 currency,
+        uint256 amount,
+        bool forcedWithdrawalAllowed
+    );
+    event TokenWithdrawn(
+        uint256 srcChainId,
+        uint256 destChainId,
+        uint256 depositId,
+        bytes32 withdrawer,
+        bytes32 recipient,
+        bytes32 currency,
+        uint256 amount
+    );
+    event RelayerChanged(address oldRelayer, address newRelayer);
+    event TokenAdded(bytes32 tokenKey, address tokenAddress, uint8 lockType);
+    event TokenRemoved(bytes32 tokenKey);
+    event ChainSupportForTokenAdded(bytes32 tokenKey, uint256 chainId);
+    event ChainSupportForTokenDropped(bytes32 tokenKey, uint256 chainId);
 
-contract LnErc20Bridge is LnAdmin {
-    using SafeMath for uint;
-    using SafeDecimalMath for uint;
-    using Address for address;
-
-    
-    struct freezeTx {
-        uint amount;
-        bool done;
-        uint timestamp;
+    struct TokenInfo {
+        address tokenAddress;
+        uint8 lockType;
     }
-    mapping(address => mapping(string => freezeTx))public freezeTxLog;
-    mapping(address => string[]) public pendingProcess;
 
-    IERC20 private erc20;
-    address private frozenHolder;
-
-
-    constructor(address _admin, address _tokenAddr) public LnAdmin(_admin) {
-        erc20 = IERC20(_tokenAddr);
-        frozenHolder = address(this);
+    struct RelayedDeposit {
+        bytes32 withdrawer;
+        bytes32 currency;
+        uint256 amount;
+        bool forcedWithdrawalAllowed;
+        bool withdrawn;
     }
 
-    //cross chain frozen data sync
-    //call from other chain
-    function setFreezeTx(address _account, string memory _txId, uint _amount, uint _timestamp) onlyAdmin public returns (bool){
-        require(_amount >= 0, "freeze amount can't zero");
-        require(_account != address(0), "need user account");
-        require(bytes(_txId).length != 0, "need txId");
+    uint256 public currentChainId;
+    address public relayer;
+    uint256 public depositCount;
+    mapping(bytes32 => TokenInfo) public tokenInfos;
+    mapping(bytes32 => mapping(uint256 => bool)) tokenSupportedOnChain;
+    mapping(uint256 => mapping(uint256 => RelayedDeposit)) relayedDeposits;
 
-        freezeTx memory _freezeTx;
-        _freezeTx.amount = _amount;
-        _freezeTx.timestamp = _timestamp;
-        _freezeTx.done = false;
-        freezeTxLog[_account][_txId] = _freezeTx;
-        pendingProcess[_account].push(_txId);
+    uint8 public constant TOKEN_LOCK_TYPE_TRANSFER = 1;
+    uint8 public constant TOKEN_LOCK_TYPE_MINT_BURN = 2;
 
-        emit SetFreezeTxLog(_account, _txId, _amount, _timestamp);
-        return true;
+    bytes4 private constant TRANSFER_SELECTOR = bytes4(keccak256(bytes("transfer(address,uint256)")));
+    bytes4 private constant TRANSFERFROM_SELECTOR = bytes4(keccak256(bytes("transferFrom(address,address,uint256)")));
+
+    modifier onlyRelayer {
+        require((msg.sender == relayer), "LnErc20Bridge: not relayer");
+        _;
     }
 
-    // need approve
-    // A chain swap to B chain.A chain call freeze,B chain call unfreeze.
-    function freeze(uint256 _amount) external returns (bool) {
-        require(_amount > 0, "freeze amount can not zero");
+    function getTokenAddress(bytes32 tokenKey) public view returns (address) {
+        return tokenInfos[tokenKey].tokenAddress;
+    }
 
-        address user = msg.sender;
+    function getTokenLockType(bytes32 tokenKey) public view returns (uint8) {
+        return tokenInfos[tokenKey].lockType;
+    }
 
-        require(erc20.balanceOf(user) >= _amount, "insufficient balance");
-        require(erc20.allowance(user, address(this)) >= _amount, "insufficient allowance, need approve more amount");
+    function isTokenSupportedOnChain(bytes32 tokenKey, uint256 chainId) public view returns (bool) {
+        return tokenSupportedOnChain[tokenKey][chainId];
+    }
 
-        erc20.transferFrom(user, frozenHolder, _amount);
+    function __LnErc20Bridge_init(address _relayer, address _admin) public initializer {
+        __LnAdminUpgradeable_init(_admin);
 
-        emit FreezeLog(user, erc20.symbol(), _amount);
-        return true;
-    }    
+        _setRelayer(_relayer);
 
-    // A chain swap to B chain.A chain call freeze,B chain call unfreeze.
-    function unfreeze(string memory _txId) external returns (bool) {
-        address user = msg.sender;
-        uint amount = freezeTxLog[user][_txId].amount;
-        
-        require(amount > 0, "unfreeze amount can not zero");
-        
-        erc20.transfer(user, amount);
-        freezeTxLog[user][_txId].done = true;
-        
-        for(uint256 i = 0; i < pendingProcess[user].length; i++){
-            if (keccak256(bytes(pendingProcess[user][i])) == keccak256(bytes(_txId))){
-                delete pendingProcess[user][i];
-            }
+        uint256 chainId;
+        assembly {
+            chainId := chainid()
+        }
+        currentChainId = chainId;
+    }
+
+    function setRelayer(address _relayer) external onlyAdmin {
+        _setRelayer(_relayer);
+    }
+
+    function addToken(
+        bytes32 tokenKey,
+        address tokenAddress,
+        uint8 lockType
+    ) external onlyAdmin {
+        require(tokenInfos[tokenKey].tokenAddress == address(0), "LnErc20Bridge: token already exists");
+        require(tokenAddress != address(0), "LnErc20Bridge: zero address");
+        require(
+            lockType == TOKEN_LOCK_TYPE_TRANSFER || lockType == TOKEN_LOCK_TYPE_MINT_BURN,
+            "LnErc20Bridge: unknown token lock type"
+        );
+
+        tokenInfos[tokenKey] = TokenInfo({tokenAddress: tokenAddress, lockType: lockType});
+        emit TokenAdded(tokenKey, tokenAddress, lockType);
+    }
+
+    function removeToken(bytes32 tokenKey) external onlyAdmin {
+        require(tokenInfos[tokenKey].tokenAddress != address(0), "LnErc20Bridge: token does not exists");
+        delete tokenInfos[tokenKey];
+        emit TokenRemoved(tokenKey);
+    }
+
+    function addChainSupportForToken(bytes32 tokenKey, uint256 chainId) external onlyAdmin {
+        require(!tokenSupportedOnChain[tokenKey][chainId], "LnErc20Bridge: already supported");
+        tokenSupportedOnChain[tokenKey][chainId] = true;
+        emit ChainSupportForTokenAdded(tokenKey, chainId);
+    }
+
+    function dropChainSupportForToken(bytes32 tokenKey, uint256 chainId) external onlyAdmin {
+        require(tokenSupportedOnChain[tokenKey][chainId], "LnErc20Bridge: not supported");
+        tokenSupportedOnChain[tokenKey][chainId] = false;
+        emit ChainSupportForTokenDropped(tokenKey, chainId);
+    }
+
+    function relay(
+        uint256 srcChainId,
+        uint256 destChainId,
+        uint256 depositId,
+        bytes32 depositor,
+        bytes32 withdrawer,
+        bytes32 currency,
+        uint256 amount,
+        bool forcedWithdrawalAllowed
+    ) external onlyRelayer {
+        require(destChainId == currentChainId, "LnErc20Bridge: wrong chain");
+        require(relayedDeposits[srcChainId][depositId].withdrawer == 0, "LnErc20Bridge: deposit already exists");
+
+        relayedDeposits[srcChainId][depositId] = RelayedDeposit({
+            withdrawer: withdrawer,
+            currency: currency,
+            amount: amount,
+            forcedWithdrawalAllowed: forcedWithdrawalAllowed,
+            withdrawn: false
+        });
+
+        emit DepositRelayed(
+            srcChainId,
+            destChainId,
+            depositId,
+            depositor,
+            withdrawer,
+            currency,
+            amount,
+            forcedWithdrawalAllowed
+        );
+    }
+
+    function deposit(
+        bytes32 token,
+        uint256 amount,
+        uint256 destChainId,
+        bytes32 withdrawer,
+        bool allowForcedWithdrawal
+    ) external {
+        require(amount > 0, "LnErc20Bridge: amount must be positive");
+        require(destChainId != currentChainId, "LnErc20Bridge: dest must be different from src");
+        require(isTokenSupportedOnChain(token, destChainId), "LnErc20Bridge: token not supported on chain");
+        require(withdrawer != 0, "LnErc20Bridge: zero address");
+
+        TokenInfo memory tokenInfo = tokenInfos[token];
+        require(tokenInfo.tokenAddress != address(0), "LnErc20Bridge: token not found");
+
+        depositCount = depositCount + 1;
+
+        if (tokenInfo.lockType == TOKEN_LOCK_TYPE_TRANSFER) {
+            safeTransferFrom(tokenInfo.tokenAddress, msg.sender, address(this), amount);
+        } else if (tokenInfo.lockType == TOKEN_LOCK_TYPE_MINT_BURN) {
+            IMintBurnToken(tokenInfo.tokenAddress).burn(msg.sender, amount);
+        } else {
+            require(false, "LnErc20Bridge: unknown token lock type");
         }
 
-        emit UnfreezeLog(user, erc20.symbol(), amount);
-        return true;
-    }  
-
-    function getTotalFrozenToken() public view returns (uint){
-        return erc20.balanceOf(address(this));
+        emit TokenDeposited(
+            currentChainId,
+            destChainId,
+            depositCount,
+            bytes32(uint256(msg.sender)),
+            withdrawer,
+            token,
+            amount,
+            allowForcedWithdrawal
+        );
     }
 
-    function getPendingProcess(address _account) public view returns (string[] memory) {
-        return pendingProcess[_account];
+    function withdraw(uint256 srcChainId, uint256 depositId) external {
+        _withdraw(srcChainId, depositId, msg.sender, true);
     }
 
-    event FreezeLog(address user, string _currency, uint256 _amount);
-    event UnfreezeLog(address user, string _currency, uint256 _amount);
-    event SetFreezeTxLog(address _account, string _txId, uint _amount, uint _timestamp);
+    function withdraw(
+        uint256 srcChainId,
+        uint256 depositId,
+        address recipient
+    ) external {
+        _withdraw(srcChainId, depositId, recipient, true);
+    }
 
+    function withdrawFor(uint256 srcChainId, uint256 depositId) external {
+        _withdraw(srcChainId, depositId, address(0), false);
+    }
 
+    function _setRelayer(address _relayer) private {
+        require(_relayer != address(0), "LnErc20Bridge: zero address");
+        require(_relayer != relayer, "LnErc20Bridge: relayer not changed");
 
+        address oldRelayer = relayer;
+        relayer = _relayer;
+
+        emit RelayerChanged(oldRelayer, relayer);
+    }
+
+    function _withdraw(
+        uint256 srcChainId,
+        uint256 depositId,
+        address recipient, // discarded when not withdrawing for self
+        bool isWithdrawingForSelf
+    ) private {
+        RelayedDeposit memory pendingDeposit = relayedDeposits[srcChainId][depositId];
+        require(pendingDeposit.withdrawer != 0, "LnErc20Bridge: deposit not found");
+        require(!pendingDeposit.withdrawn, "LnErc20Bridge: already withdrawn");
+        require(pendingDeposit.amount > 0, "LnErc20Bridge: zero amount");
+
+        if (isWithdrawingForSelf) {
+            require(pendingDeposit.withdrawer == bytes32(uint256(msg.sender)), "LnErc20Bridge: not withdrawer");
+        } else {
+            require(pendingDeposit.forcedWithdrawalAllowed, "LnErc20Bridge: forced withdrawal not allowed");
+        }
+
+        TokenInfo memory tokenInfo = tokenInfos[pendingDeposit.currency];
+        require(tokenInfo.tokenAddress != address(0), "LnErc20Bridge: token not found");
+
+        // pendingDeposit.withdrawn won't work as it's just a copy in memory
+        relayedDeposits[srcChainId][depositId].withdrawn = true;
+
+        address actualRecipient = isWithdrawingForSelf ? recipient : address(uint160(uint256(pendingDeposit.withdrawer)));
+
+        if (tokenInfo.lockType == TOKEN_LOCK_TYPE_TRANSFER) {
+            safeTransfer(tokenInfo.tokenAddress, actualRecipient, pendingDeposit.amount);
+        } else if (tokenInfo.lockType == TOKEN_LOCK_TYPE_MINT_BURN) {
+            IMintBurnToken(tokenInfo.tokenAddress).mint(actualRecipient, pendingDeposit.amount);
+        } else {
+            require(false, "LnErc20Bridge: unknown token lock type");
+        }
+
+        emit TokenWithdrawn(
+            srcChainId,
+            currentChainId,
+            depositId,
+            bytes32(uint256(msg.sender)),
+            bytes32(uint256(actualRecipient)),
+            pendingDeposit.currency,
+            pendingDeposit.amount
+        );
+    }
+
+    function safeTransfer(
+        address token,
+        address recipient,
+        uint256 amount
+    ) private {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(TRANSFER_SELECTOR, recipient, amount));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "HbtcStakingPool: transfer failed");
+    }
+
+    function safeTransferFrom(
+        address token,
+        address sender,
+        address recipient,
+        uint256 amount
+    ) private {
+        (bool success, bytes memory data) =
+            token.call(abi.encodeWithSelector(TRANSFERFROM_SELECTOR, sender, recipient, amount));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "HbtcStakingPool: transfer from failed");
+    }
 }

--- a/contracts/interfaces/IMintBurnToken.sol
+++ b/contracts/interfaces/IMintBurnToken.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+interface IMintBurnToken {
+    function mint(address account, uint256 amount) external;
+
+    function burn(address account, uint256 amount) external;
+}

--- a/contracts/mock/MockERC20.sol
+++ b/contracts/mock/MockERC20.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.6.12;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /**
  * @title MockERC20
  *
- * @dev A mintable ERC20 token contract for testing.
+ * @dev A mintable ERC20 token contract for testing. Anyone can mint or burn. DO NOT
+ * use it for production.
  */
-contract MockERC20 is ERC20, Ownable {
+contract MockERC20 is ERC20 {
     constructor(string memory _name, string memory _symbol) public ERC20(_name, _symbol) {}
 
-    function mint(address account, uint256 amount) external onlyOwner {
+    function mint(address account, uint256 amount) external {
         _mint(account, amount);
     }
 
-    function burn(address account, uint256 amount) external onlyOwner {
+    function burn(address account, uint256 amount) external {
         _burn(account, amount);
     }
 }

--- a/tests/LnErc20Bridge.spec.ts
+++ b/tests/LnErc20Bridge.spec.ts
@@ -1,0 +1,421 @@
+import { ethers, waffle } from "hardhat";
+import { expect, use } from "chai";
+import { BigNumber, Contract, Signature, Wallet } from "ethers";
+import {
+  formatBytes32String,
+  hexlify,
+  splitSignature,
+  zeroPad,
+} from "ethers/lib/utils";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expandTo18Decimals, uint256Max, zeroAddress } from "./utilities";
+
+use(waffle.solidity);
+
+const TOKEN_LOCK_TYPE_TRANSFER: number = 1;
+const TOKEN_LOCK_TYPE_MINT_BURN: number = 2;
+
+describe("LnErc20Bridge", function () {
+  let deployer: SignerWithAddress,
+    admin: SignerWithAddress,
+    alice: SignerWithAddress,
+    bob: SignerWithAddress,
+    relayer: Wallet;
+
+  let lina: Contract, lusd: Contract, lnErc20Bridge: Contract;
+
+  let currentChainId: BigNumber,
+    mockChainId: BigNumber = BigNumber.from(9999);
+
+  const createSignature = async (
+    signer: Wallet,
+    srcChainId: BigNumber,
+    destChainId: BigNumber,
+    depositId: BigNumber,
+    depositor: string,
+    recipient: string,
+    currency: string,
+    amount: BigNumber
+  ): Promise<Signature> => {
+    const domain = {
+      name: "Linear",
+      version: "1",
+      chainId: (await ethers.provider.getNetwork()).chainId,
+      verifyingContract: lnErc20Bridge.address,
+    };
+
+    const types = {
+      Deposit: [
+        { name: "srcChainId", type: "uint256" },
+        { name: "destChainId", type: "uint256" },
+        { name: "depositId", type: "uint256" },
+        { name: "depositor", type: "bytes32" },
+        { name: "recipient", type: "bytes32" },
+        { name: "currency", type: "bytes32" },
+        { name: "amount", type: "uint256" },
+      ],
+    };
+
+    const value = {
+      srcChainId,
+      destChainId,
+      depositId,
+      depositor,
+      recipient,
+      currency,
+      amount,
+    };
+
+    const signatureHex = await signer._signTypedData(domain, types, value);
+
+    return splitSignature(signatureHex);
+  };
+
+  beforeEach(async function () {
+    [deployer, admin, alice, bob] = await ethers.getSigners();
+    relayer = Wallet.createRandom();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const LnErc20Bridge = await ethers.getContractFactory("LnErc20Bridge");
+
+    currentChainId = BigNumber.from(
+      (await ethers.provider.getNetwork()).chainId
+    );
+
+    lina = await MockERC20.deploy(
+      "Linear Token", // _name
+      "LINA" // _symbol
+    );
+    lusd = await MockERC20.deploy(
+      "lUSD", // _name
+      "lUSD" // _symbol
+    );
+
+    lnErc20Bridge = await LnErc20Bridge.deploy();
+    await lnErc20Bridge.connect(deployer).__LnErc20Bridge_init(
+      relayer.address, // _relayer
+      admin.address // _admin
+    );
+
+    // Bridge does NOT need to hold any lUSD (mint/burn mode)
+    await lina
+      .connect(deployer)
+      .mint(alice.address, expandTo18Decimals(1_000_000));
+    await lina
+      .connect(deployer)
+      .mint(lnErc20Bridge.address, expandTo18Decimals(1_000_000));
+    await lusd
+      .connect(deployer)
+      .mint(alice.address, expandTo18Decimals(1_000_000));
+
+    await lina.connect(alice).approve(lnErc20Bridge.address, uint256Max);
+
+    await lnErc20Bridge.connect(admin).addToken(
+      formatBytes32String("LINA"), // tokenKey
+      lina.address, // tokenAddress
+      TOKEN_LOCK_TYPE_TRANSFER // lockType
+    );
+    await lnErc20Bridge.connect(admin).addToken(
+      formatBytes32String("lUSD"), // tokenKey
+      lusd.address, // tokenAddress
+      TOKEN_LOCK_TYPE_MINT_BURN // lockType
+    );
+    await lnErc20Bridge.connect(admin).addChainSupportForToken(
+      formatBytes32String("LINA"), // tokenKey
+      mockChainId // chainId
+    );
+    await lnErc20Bridge.connect(admin).addChainSupportForToken(
+      formatBytes32String("lUSD"), // tokenKey
+      mockChainId // chainId
+    );
+  });
+
+  it("cannot deposit with unsupported token", async () => {
+    await expect(
+      lnErc20Bridge.connect(alice).deposit(
+        formatBytes32String("NOTFOUND"), // token
+        expandTo18Decimals(1_000), // amount
+        mockChainId, // destChainId
+        hexlify(zeroPad(alice.address, 32)) // recipient
+      )
+    ).to.revertedWith("LnErc20Bridge: token not found");
+  });
+
+  it("cannot deposit for unsupported chain", async () => {
+    await expect(
+      lnErc20Bridge.connect(alice).deposit(
+        formatBytes32String("LINA"), // token
+        expandTo18Decimals(1_000), // amount
+        BigNumber.from(8888), // destChainId
+        hexlify(zeroPad(alice.address, 32)) // recipient
+      )
+    ).to.revertedWith("LnErc20Bridge: token not supported on chain");
+  });
+
+  it("token tranferred on deposit of token in transfer mode", async () => {
+    await expect(
+      lnErc20Bridge.connect(alice).deposit(
+        formatBytes32String("LINA"), // token
+        expandTo18Decimals(1_000), // amount
+        mockChainId, // destChainId
+        hexlify(zeroPad(alice.address, 32)) // recipient
+      )
+    )
+      .to.emit(lina, "Transfer")
+      .withArgs(alice.address, lnErc20Bridge.address, expandTo18Decimals(1_000))
+      .and.emit(lnErc20Bridge, "TokenDeposited")
+      .withArgs(
+        currentChainId, // srcChainId
+        mockChainId, // destChainId
+        1, // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("LINA"), // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await lina.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(999_000)
+    );
+    expect(await lina.balanceOf(lnErc20Bridge.address)).to.equal(
+      expandTo18Decimals(1_001_000)
+    );
+  });
+
+  it("token burnt on deposit of token in mint/burn mode", async () => {
+    await expect(
+      lnErc20Bridge.connect(alice).deposit(
+        formatBytes32String("lUSD"), // token
+        expandTo18Decimals(1_000), // amount
+        mockChainId, // destChainId
+        hexlify(zeroPad(alice.address, 32)) // recipient
+      )
+    )
+      .to.emit(lusd, "Transfer")
+      .withArgs(alice.address, zeroAddress, expandTo18Decimals(1_000))
+      .and.emit(lnErc20Bridge, "TokenDeposited")
+      .withArgs(
+        currentChainId, // srcChainId
+        mockChainId, // destChainId
+        1, // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("lUSD"), // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await lusd.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(999_000)
+    );
+    expect(await lusd.balanceOf(lnErc20Bridge.address)).to.equal(0);
+  });
+
+  it("cannot withdraw with invalid signature", async () => {
+    // Signature with wrong depositId
+    const signature = await createSignature(
+      relayer, // signer
+      mockChainId, // srcChainId
+      currentChainId, // destChainId
+      BigNumber.from(999), // depositId
+      hexlify(zeroPad(alice.address, 32)), // depositor
+      hexlify(zeroPad(alice.address, 32)), // recipient
+      formatBytes32String("LINA"), // currency
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await expect(
+      lnErc20Bridge.connect(alice).withdraw(
+        mockChainId, // srcChainId
+        currentChainId, // destChainId
+        BigNumber.from(1), // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("LINA"), // currency
+        expandTo18Decimals(1000), // amount
+        signature.v, // v
+        signature.r, // r
+        signature.s // s
+      )
+    ).to.revertedWith("LnErc20Bridge: invalid signature");
+  });
+
+  it("token tranferred on withdrawal of token in transfer mode", async () => {
+    const signature = await createSignature(
+      relayer, // signer
+      mockChainId, // srcChainId
+      currentChainId, // destChainId
+      BigNumber.from(1), // depositId
+      hexlify(zeroPad(alice.address, 32)), // depositor
+      hexlify(zeroPad(alice.address, 32)), // recipient
+      formatBytes32String("LINA"), // currency
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await expect(
+      lnErc20Bridge.connect(alice).withdraw(
+        mockChainId, // srcChainId
+        currentChainId, // destChainId
+        BigNumber.from(1), // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("LINA"), // currency
+        expandTo18Decimals(1000), // amount
+        signature.v, // v
+        signature.r, // r
+        signature.s // s
+      )
+    )
+      .to.emit(lina, "Transfer")
+      .withArgs(lnErc20Bridge.address, alice.address, expandTo18Decimals(1_000))
+      .and.emit(lnErc20Bridge, "TokenWithdrawn")
+      .withArgs(
+        mockChainId, // srcChainId
+        currentChainId, // destChainId
+        1, // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("LINA"), // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await lina.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(1_001_000)
+    );
+    expect(await lina.balanceOf(lnErc20Bridge.address)).to.equal(
+      expandTo18Decimals(999_000)
+    );
+  });
+
+  it("token minted on withdrawal of token in mint/burn mode", async () => {
+    const signature = await createSignature(
+      relayer, // signer
+      mockChainId, // srcChainId
+      currentChainId, // destChainId
+      BigNumber.from(1), // depositId
+      hexlify(zeroPad(alice.address, 32)), // depositor
+      hexlify(zeroPad(alice.address, 32)), // recipient
+      formatBytes32String("lUSD"), // currency
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await expect(
+      lnErc20Bridge.connect(alice).withdraw(
+        mockChainId, // srcChainId
+        currentChainId, // destChainId
+        BigNumber.from(1), // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("lUSD"), // currency
+        expandTo18Decimals(1000), // amount
+        signature.v, // v
+        signature.r, // r
+        signature.s // s
+      )
+    )
+      .to.emit(lusd, "Transfer")
+      .withArgs(zeroAddress, alice.address, expandTo18Decimals(1_000))
+      .and.emit(lnErc20Bridge, "TokenWithdrawn")
+      .withArgs(
+        mockChainId, // srcChainId
+        currentChainId, // destChainId
+        1, // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("lUSD"), // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await lusd.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(1_001_000)
+    );
+    expect(await lusd.balanceOf(lnErc20Bridge.address)).to.equal(0);
+  });
+
+  it("cannot withdraw the same deposit multiple times", async () => {
+    const signature = await createSignature(
+      relayer, // signer
+      mockChainId, // srcChainId
+      currentChainId, // destChainId
+      BigNumber.from(1), // depositId
+      hexlify(zeroPad(alice.address, 32)), // depositor
+      hexlify(zeroPad(alice.address, 32)), // recipient
+      formatBytes32String("LINA"), // currency
+      expandTo18Decimals(1_000) // amount
+    );
+
+    // The first withdrawal is successful
+    await lnErc20Bridge.connect(alice).withdraw(
+      mockChainId, // srcChainId
+      currentChainId, // destChainId
+      BigNumber.from(1), // depositId
+      hexlify(zeroPad(alice.address, 32)), // depositor
+      hexlify(zeroPad(alice.address, 32)), // recipient
+      formatBytes32String("LINA"), // currency
+      expandTo18Decimals(1000), // amount
+      signature.v, // v
+      signature.r, // r
+      signature.s // s
+    );
+
+    await expect(
+      lnErc20Bridge.connect(alice).withdraw(
+        mockChainId, // srcChainId
+        currentChainId, // destChainId
+        BigNumber.from(1), // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("LINA"), // currency
+        expandTo18Decimals(1000), // amount
+        signature.v, // v
+        signature.r, // r
+        signature.s // s
+      )
+    ).to.revertedWith("LnErc20Bridge: already withdrawn");
+  });
+
+  it("depositId should increment on each deposit", async () => {
+    expect(await lnErc20Bridge.depositCount()).to.equal(0);
+
+    await expect(
+      lnErc20Bridge.connect(alice).deposit(
+        formatBytes32String("lUSD"), // token
+        expandTo18Decimals(1_000), // amount
+        mockChainId, // destChainId
+        hexlify(zeroPad(alice.address, 32)) // recipient
+      )
+    )
+      .to.emit(lnErc20Bridge, "TokenDeposited")
+      .withArgs(
+        currentChainId, // srcChainId
+        mockChainId, // destChainId
+        1, // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("lUSD"), // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await lnErc20Bridge.depositCount()).to.equal(1);
+
+    await expect(
+      lnErc20Bridge.connect(alice).deposit(
+        formatBytes32String("lUSD"), // token
+        expandTo18Decimals(1_000), // amount
+        mockChainId, // destChainId
+        hexlify(zeroPad(alice.address, 32)) // recipient
+      )
+    )
+      .to.emit(lnErc20Bridge, "TokenDeposited")
+      .withArgs(
+        currentChainId, // srcChainId
+        mockChainId, // destChainId
+        2, // depositId
+        hexlify(zeroPad(alice.address, 32)), // depositor
+        hexlify(zeroPad(alice.address, 32)), // recipient
+        formatBytes32String("lUSD"), // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await lnErc20Bridge.depositCount()).to.equal(2);
+  });
+});

--- a/tests/LnErc20Bridge.spec.ts
+++ b/tests/LnErc20Bridge.spec.ts
@@ -36,7 +36,7 @@ describe("LnErc20Bridge", function () {
     recipient: string,
     currency: string,
     amount: BigNumber
-  ): Promise<Signature> => {
+  ): Promise<string> => {
     const domain = {
       name: "Linear",
       version: "1",
@@ -68,7 +68,7 @@ describe("LnErc20Bridge", function () {
 
     const signatureHex = await signer._signTypedData(domain, types, value);
 
-    return splitSignature(signatureHex);
+    return signatureHex;
   };
 
   beforeEach(async function () {
@@ -232,9 +232,7 @@ describe("LnErc20Bridge", function () {
         hexlify(zeroPad(alice.address, 32)), // recipient
         formatBytes32String("LINA"), // currency
         expandTo18Decimals(1000), // amount
-        signature.v, // v
-        signature.r, // r
-        signature.s // s
+        signature // signature
       )
     ).to.revertedWith("LnErc20Bridge: invalid signature");
   });
@@ -260,9 +258,7 @@ describe("LnErc20Bridge", function () {
         hexlify(zeroPad(alice.address, 32)), // recipient
         formatBytes32String("LINA"), // currency
         expandTo18Decimals(1000), // amount
-        signature.v, // v
-        signature.r, // r
-        signature.s // s
+        signature // signature
       )
     )
       .to.emit(lina, "Transfer")
@@ -307,9 +303,7 @@ describe("LnErc20Bridge", function () {
         hexlify(zeroPad(alice.address, 32)), // recipient
         formatBytes32String("lUSD"), // currency
         expandTo18Decimals(1000), // amount
-        signature.v, // v
-        signature.r, // r
-        signature.s // s
+        signature // signature
       )
     )
       .to.emit(lusd, "Transfer")
@@ -352,9 +346,7 @@ describe("LnErc20Bridge", function () {
       hexlify(zeroPad(alice.address, 32)), // recipient
       formatBytes32String("LINA"), // currency
       expandTo18Decimals(1000), // amount
-      signature.v, // v
-      signature.r, // r
-      signature.s // s
+      signature // signature
     );
 
     await expect(
@@ -366,9 +358,7 @@ describe("LnErc20Bridge", function () {
         hexlify(zeroPad(alice.address, 32)), // recipient
         formatBytes32String("LINA"), // currency
         expandTo18Decimals(1000), // amount
-        signature.v, // v
-        signature.r, // r
-        signature.s // s
+        signature // signature
       )
     ).to.revertedWith("LnErc20Bridge: already withdrawn");
   });


### PR DESCRIPTION
This PR:

- adds a new contract `LnErc20Bridge` and relevant test cases;
- allows anyone to mint or burn tokens with `MockERC20`.