### PR TITLE
Remove unused contract imports

### DIFF
--- a/contracts/LnAccessControl.sol
+++ b/contracts/LnAccessControl.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 
 // example:
 //LnAccessControl accessCtrl = LnAccessControl(addressStorage.getAddress("LnAccessControl"));
@@ -10,8 +9,6 @@ import "@openzeppelin/contracts/utils/Address.sol";
 
 // contract access control
 contract LnAccessControl is AccessControl {
-    using Address for address;
-
     // -------------------------------------------------------
     // role type
     bytes32 public constant ISSUE_ASSET_ROLE = ("ISSUE_ASSET"); //keccak256

--- a/contracts/LnAssetSystem.sol
+++ b/contracts/LnAssetSystem.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.6.12;
 
-import "./LnAddressCache.sol";
 import "./IAsset.sol";
 import "./LnAssetUpgradeable.sol";
 import "./LnPrices.sol";

--- a/contracts/LnBuildBurnSystem.sol
+++ b/contracts/LnBuildBurnSystem.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.6.12;
 
-import "./IERC20.sol";
 import "./LnAdmin.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 import "./SafeDecimalMath.sol";
 import "./LnPrices.sol";
 import "./LnAddressCache.sol";
@@ -19,7 +17,6 @@ import "./LnConfig.sol";
 contract LnBuildBurnSystem is LnAdmin, Pausable, LnAddressCache {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
-    using Address for address;
 
     // -------------------------------------------------------
     // need set before system running value.

--- a/contracts/LnDebtSystem.sol
+++ b/contracts/LnDebtSystem.sol
@@ -3,17 +3,14 @@ pragma solidity ^0.6.12;
 
 import "./upgradeable/LnAdminUpgradeable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 import "./SafeDecimalMath.sol";
 import "./LnAddressCache.sol";
 import "./LnAccessControl.sol";
 import "./LnAssetSystem.sol";
-import "./LnConfig.sol";
 
 contract LnDebtSystem is LnAdminUpgradeable, LnAddressCache {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
-    using Address for address;
 
     // -------------------------------------------------------
     // need set before system running value.

--- a/contracts/LnLinearStaking.sol
+++ b/contracts/LnLinearStaking.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.6.12;
 
 import "./IERC20.sol";
 import "./LnAdmin.sol";
-import "./LnOperatorModifier.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
 import "./LnAccessControl.sol";

--- a/contracts/LnSimpleStaking.sol
+++ b/contracts/LnSimpleStaking.sol
@@ -3,12 +3,9 @@ pragma solidity ^0.6.12;
 
 import "./IERC20.sol";
 import "./LnAdmin.sol";
-import "./LnOperatorModifier.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
-import "./LnAccessControl.sol";
 import "./LnLinearStaking.sol";
-import "./SafeDecimalMath.sol";
 
 contract LnRewardCalculator {
     using SafeMath for uint256;
@@ -245,9 +242,6 @@ contract LnSimpleStaking is
     ILinearStaking,
     LnRewardCalculator
 {
-    using SafeMath for uint256;
-    using SafeDecimalMath for uint256;
-
     IERC20 public linaToken; // lina token proxy address
     LnLinearStakingStorage public stakingStorage;
     uint256 public mEndBlock;
@@ -652,9 +646,6 @@ contract LnSimpleStakingExtension is
     ILinearStaking,
     LnRewardCalculator
 {
-    using SafeMath for uint256;
-    using SafeDecimalMath for uint256;
-
     IERC20 public linaToken; // lina token proxy address
     uint256 public mEndBlock;
 
@@ -998,9 +989,6 @@ contract LnSimpleStakingNew is
     ILinearStaking,
     LnRewardCalculator
 {
-    using SafeMath for uint256;
-    using SafeDecimalMath for uint256;
-
     IERC20 public linaToken; // lina token proxy address
     LnSimpleStaking public simpleStaking;
     uint256 public mEndBlock;

--- a/contracts/LnTokenLocker.sol
+++ b/contracts/LnTokenLocker.sol
@@ -3,10 +3,8 @@ pragma solidity ^0.6.12;
 
 import "./IERC20.sol";
 import "./LnAdmin.sol";
-import "./SafeDecimalMath.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 
 // approve
 contract LnTokenLocker is LnAdmin, Pausable {


### PR DESCRIPTION
Fixes #36.

This PR removes unused imports as well as unused `using`s.