### PR TITLE
Apply code formatter to all contracts and tests

### DIFF
--- a/.github/workflows/check-code-format.yml
+++ b/.github/workflows/check-code-format.yml
@@ -1,0 +1,27 @@
+name: Check Code Format
+
+on:
+  push:
+    branches:
+      - "master"
+
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  validate-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone Source Code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Validate Format of Contracts
+        run: yarn prettier --check ./contracts/
+
+      - name: Validate Format of Tests
+        run: yarn prettier --check ./tests/

--- a/contracts/LnAccessControl.sol
+++ b/contracts/LnAccessControl.sol
@@ -15,6 +15,7 @@ contract LnAccessControl is AccessControl {
     bytes32 public constant BURN_ASSET_ROLE = ("BURN_ASSET");
 
     bytes32 public constant DEBT_SYSTEM = ("LnDebtSystem");
+
     // -------------------------------------------------------
     constructor(address admin) public {
         _setupRole(DEFAULT_ADMIN_ROLE, admin);
@@ -32,16 +33,24 @@ contract LnAccessControl is AccessControl {
 
     // -------------------------------------------------------
     // this func need admin role. grantRole and revokeRole need admin role
-    function SetRoles(bytes32 roleType, address[] calldata addresses, bool[] calldata setTo) external {
+    function SetRoles(
+        bytes32 roleType,
+        address[] calldata addresses,
+        bool[] calldata setTo
+    ) external {
         require(IsAdmin(msg.sender), "Only admin");
 
         _setRoles(roleType, addresses, setTo);
     }
 
-    function _setRoles(bytes32 roleType, address[] calldata addresses, bool[] calldata setTo) private {
+    function _setRoles(
+        bytes32 roleType,
+        address[] calldata addresses,
+        bool[] calldata setTo
+    ) private {
         require(addresses.length == setTo.length, "parameter address length not eq");
 
-        for (uint256 i=0; i < addresses.length; i++) {
+        for (uint256 i = 0; i < addresses.length; i++) {
             //require(addresses[i].isContract(), "Role address need contract only");
             if (setTo[i]) {
                 grantRole(roleType, addresses[i]);
@@ -63,7 +72,7 @@ contract LnAccessControl is AccessControl {
     function SetBurnAssetRole(address[] calldata burner, bool[] calldata setTo) public {
         _setRoles(BURN_ASSET_ROLE, burner, setTo);
     }
-    
+
     //
     function SetDebtSystemRole(address[] calldata _address, bool[] calldata _setTo) public {
         _setRoles(DEBT_SYSTEM, _address, _setTo);

--- a/contracts/LnAddressCache.sol
+++ b/contracts/LnAddressCache.sol
@@ -4,25 +4,22 @@ pragma solidity ^0.6.12;
 import "./LnAdmin.sol";
 import "./interfaces/ILnAddressStorage.sol";
 
-abstract contract LnAddressCache  {
-    function updateAddressCache( ILnAddressStorage _addressStorage )  external virtual ;
+abstract contract LnAddressCache {
+    function updateAddressCache(ILnAddressStorage _addressStorage) external virtual;
 
-    event   CachedAddressUpdated( bytes32 name, address addr );
+    event CachedAddressUpdated(bytes32 name, address addr);
 }
 
-contract testAddressCache  is LnAddressCache, LnAdmin {
+contract testAddressCache is LnAddressCache, LnAdmin {
     address public addr1;
     address public addr2;
-    
-    constructor(address _admin ) public LnAdmin(_admin ) {}
 
+    constructor(address _admin) public LnAdmin(_admin) {}
 
-    function updateAddressCache( ILnAddressStorage _addressStorage ) onlyAdmin public override
-    {
+    function updateAddressCache(ILnAddressStorage _addressStorage) public override onlyAdmin {
         addr1 = _addressStorage.getAddressWithRequire("a", "");
-        addr2 = _addressStorage.getAddressWithRequire("b", "" );
-        emit CachedAddressUpdated( "a", addr1 );
-        emit CachedAddressUpdated( "b", addr2 );
+        addr2 = _addressStorage.getAddressWithRequire("b", "");
+        emit CachedAddressUpdated("a", addr1);
+        emit CachedAddressUpdated("b", addr2);
     }
-
 }

--- a/contracts/LnAdmin.sol
+++ b/contracts/LnAdmin.sol
@@ -14,22 +14,21 @@ contract LnAdmin {
     function setCandidate(address _candidate) external onlyAdmin {
         address old = candidate;
         candidate = _candidate;
-        emit CandidateChanged( old, candidate);
+        emit CandidateChanged(old, candidate);
     }
 
-    function becomeAdmin( ) external {
-        require( msg.sender == candidate, "Only candidate can become admin");
+    function becomeAdmin() external {
+        require(msg.sender == candidate, "Only candidate can become admin");
         address old = admin;
         admin = candidate;
-        emit AdminChanged( old, admin ); 
+        emit AdminChanged(old, admin);
     }
 
     modifier onlyAdmin {
-        require( (msg.sender == admin), "Only the contract admin can perform this action");
+        require((msg.sender == admin), "Only the contract admin can perform this action");
         _;
     }
 
-    event CandidateChanged(address oldCandidate, address newCandidate );
+    event CandidateChanged(address oldCandidate, address newCandidate);
     event AdminChanged(address oldAdmin, address newAdmin);
 }
-

--- a/contracts/LnAssetSystem.sol
+++ b/contracts/LnAssetSystem.sol
@@ -14,9 +14,9 @@ contract LnAssetSystem is LnAddressStorage {
     ILnAsset[] public mAssetList; // 合约地址数组
     mapping(address => bytes32) public mAddress2Names; // 地址到名称的映射
 
-    constructor(address _admin ) public LnAddressStorage(_admin ) {}
+    constructor(address _admin) public LnAddressStorage(_admin) {}
 
-    function addAsset( ILnAsset asset ) external onlyAdmin {
+    function addAsset(ILnAsset asset) external onlyAdmin {
         bytes32 name = asset.keyName();
 
         require(mAddrs[name] == address(0), "Asset already exists");
@@ -32,7 +32,7 @@ contract LnAssetSystem is LnAddressStorage {
     function removeAsset(bytes32 name) external onlyAdmin {
         address assetToRemove = address(mAddrs[name]);
 
-        require( assetToRemove != address(0), "asset does not exist");
+        require(assetToRemove != address(0), "asset does not exist");
 
         // Remove from list
         for (uint i = 0; i < mAssetList.length; i++) {
@@ -45,7 +45,7 @@ contract LnAssetSystem is LnAddressStorage {
         }
 
         // And remove it from the assets mapping
-        delete mAddress2Names[ assetToRemove ];
+        delete mAddress2Names[assetToRemove];
         delete mAddrs[name];
 
         emit AssetRemoved(name, assetToRemove);
@@ -58,16 +58,16 @@ contract LnAssetSystem is LnAddressStorage {
     // check exchange rate invalid condition ? invalid just fail.
     function totalAssetsInUsd() public view returns (uint256 rTotal) {
         require(mAddrs["LnPrices"] != address(0), "LnPrices address cannot access");
-        ILnPrices priceGetter = ILnPrices( mAddrs["LnPrices"] ); //getAddress
-        for (uint256 i=0; i< mAssetList.length; i++) {
+        ILnPrices priceGetter = ILnPrices(mAddrs["LnPrices"]); //getAddress
+        for (uint256 i = 0; i < mAssetList.length; i++) {
             uint256 exchangeRate = priceGetter.getPrice(mAssetList[i].keyName());
-            rTotal = rTotal.add( mAssetList[i].totalSupply().multiplyDecimal(exchangeRate) );
+            rTotal = rTotal.add(mAssetList[i].totalSupply().multiplyDecimal(exchangeRate));
         }
     }
 
-    function getAssetAddresses() external view returns(address[] memory) {
+    function getAssetAddresses() external view returns (address[] memory) {
         address[] memory addr = new address[](mAssetList.length);
-        for (uint256 i=0; i<mAssetList.length; i++) {
+        for (uint256 i = 0; i < mAssetList.length; i++) {
             addr[i] = address(mAssetList[i]);
         }
         return addr;
@@ -76,4 +76,3 @@ contract LnAssetSystem is LnAddressStorage {
     event AssetAdded(bytes32 name, address asset);
     event AssetRemoved(bytes32 name, address asset);
 }
-

--- a/contracts/LnChainLinkPrices.sol
+++ b/contracts/LnChainLinkPrices.sol
@@ -16,10 +16,6 @@ interface OracleInterface {
     function getTimestamp(uint256 roundId) external view returns (uint256);
 }
 
-
-
-
-
 contract LnChainLinkPrices is LnDefaultPrices {
     mapping(bytes32 => OracleInterface) public mOracles;
 
@@ -55,9 +51,9 @@ contract LnChainLinkPrices is LnDefaultPrices {
             priceAndTime.mTime = uint40(Oracle.latestTimestamp());
             return priceAndTime;
         } else {
-            return super._getPriceData( currencyName );
+            return super._getPriceData(currencyName);
         }
-    }  
+    }
 
     function removeFromArray(bytes32 entry, bytes32[] storage array) internal returns (bool) {
         for (uint i = 0; i < array.length; i++) {
@@ -71,11 +67,9 @@ contract LnChainLinkPrices is LnDefaultPrices {
         return false;
     }
 
-
     event OracleAdded(bytes32 currencyKey, address Oracle);
     event OracleRemoved(bytes32 currencyKey, address Oracle);
 }
-
 
 // test Oracle, for test stub
 contract TestOracle is OracleInterface {

--- a/contracts/LnCollateralSystem.sol
+++ b/contracts/LnCollateralSystem.sol
@@ -27,9 +27,9 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
     ILnConfig public mConfig;
     ILnRewardLocker public mRewardLocker;
 
-    bytes32 constant public Currency_ETH = "ETH";
-    bytes32 constant public Currency_LINA = "LINA";
-    
+    bytes32 public constant Currency_ETH = "ETH";
+    bytes32 public constant Currency_LINA = "LINA";
+
     // -------------------------------------------------------
     uint256 public uniqueId; // use log
 
@@ -40,7 +40,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         bool bClose; // TODO : 为了防止价格波动，另外再加个折扣价?
     }
 
-    mapping (bytes32 => TokenInfo) public tokenInfos;
+    mapping(bytes32 => TokenInfo) public tokenInfos;
     bytes32[] public tokenSymbol; // keys of tokenInfos, use to iteration
 
     struct CollateralData {
@@ -48,7 +48,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
     }
 
     // [user] => ([token=> collateraldata])
-    mapping (address => mapping(bytes32 => CollateralData)) public userCollateralData;
+    mapping(address => mapping(bytes32 => CollateralData)) public userCollateralData;
 
     // -------------------------------------------------------
     function __LnCollateralSystem_init(address _admin) public initializer {
@@ -62,48 +62,71 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
             _unpause();
         }
     }
-    // ------------------ system config ----------------------
-    function updateAddressCache( ILnAddressStorage _addressStorage ) onlyAdmin public override
-    {
-        priceGetter =     ILnPrices(         _addressStorage.getAddressWithRequire( "LnPrices",          "LnPrices address not valid" ));
-        debtSystem =      ILnDebtSystem(     _addressStorage.getAddressWithRequire( "LnDebtSystem",      "LnDebtSystem address not valid" ));
-        mConfig =         ILnConfig(         _addressStorage.getAddressWithRequire( "LnConfig",          "LnConfig address not valid" ) );
-        mRewardLocker =   ILnRewardLocker(   _addressStorage.getAddressWithRequire( "LnRewardLocker",    "LnRewardLocker address not valid" ));
 
-        emit CachedAddressUpdated( "LnPrices",          address(priceGetter) );
-        emit CachedAddressUpdated( "LnDebtSystem",      address(debtSystem) );
-        emit CachedAddressUpdated( "LnConfig",          address(mConfig) );
-        emit CachedAddressUpdated( "LnRewardLocker",    address(mRewardLocker) );
+    // ------------------ system config ----------------------
+    function updateAddressCache(ILnAddressStorage _addressStorage) public override onlyAdmin {
+        priceGetter = ILnPrices(_addressStorage.getAddressWithRequire("LnPrices", "LnPrices address not valid"));
+        debtSystem = ILnDebtSystem(_addressStorage.getAddressWithRequire("LnDebtSystem", "LnDebtSystem address not valid"));
+        mConfig = ILnConfig(_addressStorage.getAddressWithRequire("LnConfig", "LnConfig address not valid"));
+        mRewardLocker = ILnRewardLocker(
+            _addressStorage.getAddressWithRequire("LnRewardLocker", "LnRewardLocker address not valid")
+        );
+
+        emit CachedAddressUpdated("LnPrices", address(priceGetter));
+        emit CachedAddressUpdated("LnDebtSystem", address(debtSystem));
+        emit CachedAddressUpdated("LnConfig", address(mConfig));
+        emit CachedAddressUpdated("LnRewardLocker", address(mRewardLocker));
     }
 
-    function updateTokenInfo(bytes32 _currency, address _tokenAddr, uint256 _minCollateral, bool _close) private returns (bool) {
+    function updateTokenInfo(
+        bytes32 _currency,
+        address _tokenAddr,
+        uint256 _minCollateral,
+        bool _close
+    ) private returns (bool) {
         require(_currency[0] != 0, "symbol cannot empty");
         require(_currency != Currency_ETH, "ETH is used by system");
         require(_tokenAddr != address(0), "token address cannot zero");
         require(_tokenAddr.isContract(), "token address is not a contract");
 
-        if (tokenInfos[_currency].tokenAddr == address(0)) {// new token
+        if (tokenInfos[_currency].tokenAddr == address(0)) {
+            // new token
             tokenSymbol.push(_currency);
         }
 
         uint256 totalCollateral = tokenInfos[_currency].totalCollateral;
-        tokenInfos[_currency] = TokenInfo({tokenAddr:_tokenAddr, minCollateral:_minCollateral, totalCollateral:totalCollateral, bClose:_close});
+        tokenInfos[_currency] = TokenInfo({
+            tokenAddr: _tokenAddr,
+            minCollateral: _minCollateral,
+            totalCollateral: totalCollateral,
+            bClose: _close
+        });
         emit UpdateTokenSetting(_currency, _tokenAddr, _minCollateral, _close);
         return true;
     }
 
     // delete token info? need to handle it's staking data.
 
-    function UpdateTokenInfo(bytes32 _currency, address _tokenAddr, uint256 _minCollateral, bool _close) external onlyAdmin returns (bool) {
+    function UpdateTokenInfo(
+        bytes32 _currency,
+        address _tokenAddr,
+        uint256 _minCollateral,
+        bool _close
+    ) external onlyAdmin returns (bool) {
         return updateTokenInfo(_currency, _tokenAddr, _minCollateral, _close);
     }
 
-    function UpdateTokenInfos(bytes32[] calldata _symbols, address[] calldata _tokenAddrs, uint256[] calldata _minCollateral, bool[] calldata _closes) external onlyAdmin returns (bool) {
+    function UpdateTokenInfos(
+        bytes32[] calldata _symbols,
+        address[] calldata _tokenAddrs,
+        uint256[] calldata _minCollateral,
+        bool[] calldata _closes
+    ) external onlyAdmin returns (bool) {
         require(_symbols.length == _tokenAddrs.length, "length of array not eq");
         require(_symbols.length == _minCollateral.length, "length of array not eq");
         require(_symbols.length == _closes.length, "length of array not eq");
 
-        for (uint256 i=0; i < _symbols.length; i++) {
+        for (uint256 i = 0; i < _symbols.length; i++) {
             updateTokenInfo(_symbols[i], _tokenAddrs[i], _minCollateral[i], _closes[i]);
         }
 
@@ -112,14 +135,14 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
 
     // ------------------------------------------------------------------------
     function GetSystemTotalCollateralInUsd() public view returns (uint256 rTotal) {
-        for (uint256 i=0; i< tokenSymbol.length; i++) {
+        for (uint256 i = 0; i < tokenSymbol.length; i++) {
             bytes32 currency = tokenSymbol[i];
             uint256 collateralAmount = tokenInfos[currency].totalCollateral;
             if (Currency_LINA == currency) {
                 collateralAmount = collateralAmount.add(mRewardLocker.totalNeedToReward());
             }
             if (collateralAmount > 0) {
-                rTotal = rTotal.add( collateralAmount.multiplyDecimal(priceGetter.getPrice(currency)) );
+                rTotal = rTotal.add(collateralAmount.multiplyDecimal(priceGetter.getPrice(currency)));
             }
         }
 
@@ -129,19 +152,21 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
     }
 
     function GetUserTotalCollateralInUsd(address _user) public view returns (uint256 rTotal) {
-        for (uint256 i=0; i< tokenSymbol.length; i++) {
+        for (uint256 i = 0; i < tokenSymbol.length; i++) {
             bytes32 currency = tokenSymbol[i];
             uint256 collateralAmount = userCollateralData[_user][currency].collateral;
             if (Currency_LINA == currency) {
                 collateralAmount = collateralAmount.add(mRewardLocker.balanceOf(_user));
             }
             if (collateralAmount > 0) {
-                rTotal = rTotal.add( collateralAmount.multiplyDecimal(priceGetter.getPrice(currency)) );
+                rTotal = rTotal.add(collateralAmount.multiplyDecimal(priceGetter.getPrice(currency)));
             }
         }
 
         if (userCollateralData[_user][Currency_ETH].collateral > 0) {
-            rTotal = rTotal.add( userCollateralData[_user][Currency_ETH].collateral.multiplyDecimal(priceGetter.getPrice(Currency_ETH)) );
+            rTotal = rTotal.add(
+                userCollateralData[_user][Currency_ETH].collateral.multiplyDecimal(priceGetter.getPrice(Currency_ETH))
+            );
         }
     }
 
@@ -157,7 +182,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         bytes32[] memory rCurrency = new bytes32[](tokenSymbol.length + 1);
         uint256[] memory rAmount = new uint256[](tokenSymbol.length + 1);
         uint256 retSize = 0;
-        for (uint256 i=0; i < tokenSymbol.length; i++) {
+        for (uint256 i = 0; i < tokenSymbol.length; i++) {
             bytes32 currency = tokenSymbol[i];
             if (userCollateralData[_user][currency].collateral > 0) {
                 rCurrency[retSize] = currency;
@@ -171,7 +196,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
             retSize++;
         }
 
-        return (rCurrency, rAmount); 
+        return (rCurrency, rAmount);
     }
 
     /**
@@ -221,7 +246,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         return true;
     }
 
-    function IsSatisfyTargetRatio(address _user) public view returns(bool) {
+    function IsSatisfyTargetRatio(address _user) public view returns (bool) {
         (uint256 debtBalance, ) = debtSystem.GetUserDebtBalanceInUsd(_user);
         if (debtBalance == 0) {
             return true;
@@ -239,7 +264,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
     // 满足最低抵押率的情况下可最大赎回的资产 TODO: return multi value
     function MaxRedeemableInUsd(address _user) public view returns (uint256) {
         uint256 totalCollateralInUsd = GetUserTotalCollateralInUsd(_user);
-        
+
         (uint256 debtBalance, ) = debtSystem.GetUserDebtBalanceInUsd(_user);
         if (debtBalance == 0) {
             return totalCollateralInUsd;
@@ -250,11 +275,11 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         if (totalCollateralInUsd < minCollateral) {
             return 0;
         }
-        
+
         return totalCollateralInUsd.sub(minCollateral);
     }
 
-    function MaxRedeemable(address user, bytes32 _currency) public view returns(uint256) {
+    function MaxRedeemable(address user, bytes32 _currency) public view returns (uint256) {
         uint256 maxRedeemableInUsd = MaxRedeemableInUsd(user);
         uint256 maxRedeem = maxRedeemableInUsd.divideDecimal(priceGetter.getPrice(_currency));
         if (maxRedeem > userCollateralData[user][_currency].collateral) {
@@ -276,7 +301,11 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         _Redeem(user, _currency, maxRedeem);
     }
 
-    function _Redeem(address user, bytes32 _currency, uint256 _amount) internal {
+    function _Redeem(
+        address user,
+        bytes32 _currency,
+        uint256 _amount
+    ) internal {
         require(_amount <= userCollateralData[user][_currency].collateral, "Can not redeem more than collateral");
         require(_amount > 0, "Redeem amount need larger than zero");
 
@@ -302,7 +331,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         return true;
     }
 
-    receive() external whenNotPaused payable {
+    receive() external payable whenNotPaused {
         address user = msg.sender;
         uint256 ethAmount = msg.value;
         _CollateralEth(user, ethAmount);
@@ -310,13 +339,13 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
 
     function _CollateralEth(address user, uint256 ethAmount) internal {
         require(ethAmount > 0, "ETH amount need more than zero");
-        
+
         userCollateralData[user][Currency_ETH].collateral = userCollateralData[user][Currency_ETH].collateral.add(ethAmount);
 
         emit CollateralLog(user, Currency_ETH, ethAmount, userCollateralData[user][Currency_ETH].collateral);
     }
 
-    // payable eth receive, 
+    // payable eth receive,
     function CollateralEth() external payable whenNotPaused returns (bool) {
         address user = msg.sender;
         uint256 ethAmount = msg.value;
@@ -330,7 +359,7 @@ contract LnCollateralSystem is LnAdminUpgradeable, PausableUpgradeable, LnAddres
         require(_amount > 0, "Redeem amount need larger than zero");
 
         uint256 maxRedeemableInUsd = MaxRedeemableInUsd(user);
-        
+
         uint256 maxRedeem = maxRedeemableInUsd.divideDecimal(priceGetter.getPrice(Currency_ETH));
         require(_amount <= maxRedeem, "Because lower collateral ratio, can not redeem too much");
 

--- a/contracts/LnConfig.sol
+++ b/contracts/LnConfig.sol
@@ -1,31 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.6.12;
 
-
 import "./LnAdmin.sol";
 
 contract LnConfig is LnAdmin {
-
     mapping(bytes32 => uint) internal mUintConfig;
 
-    constructor(address _admin ) public LnAdmin(_admin ) {}
+    constructor(address _admin) public LnAdmin(_admin) {}
 
     //some configue keys
     bytes32 public constant BUILD_RATIO = "BuildRatio"; // percent, base 10e18
 
-    function getUint(bytes32 key ) external view returns (uint) {
+    function getUint(bytes32 key) external view returns (uint) {
         return mUintConfig[key];
     }
 
     function setUint(bytes32 key, uint value) external onlyAdmin {
         mUintConfig[key] = value;
-        emit SetUintConfig( key, value );
+        emit SetUintConfig(key, value);
     }
 
-    
-    function deleteUint(bytes32 key ) external onlyAdmin {
+    function deleteUint(bytes32 key) external onlyAdmin {
         delete mUintConfig[key];
-        emit SetUintConfig( key, 0 );
+        emit SetUintConfig(key, 0);
     }
 
     function batchSet(bytes32[] calldata names, uint[] calldata values) external onlyAdmin {
@@ -33,9 +30,9 @@ contract LnConfig is LnAdmin {
 
         for (uint i = 0; i < names.length; i++) {
             mUintConfig[names[i]] = values[i];
-            emit SetUintConfig( names[i], values[i] );
+            emit SetUintConfig(names[i], values[i]);
         }
     }
 
-    event SetUintConfig( bytes32 key, uint value );
+    event SetUintConfig(bytes32 key, uint value);
 }

--- a/contracts/LnDefaultPrices.sol
+++ b/contracts/LnDefaultPrices.sol
@@ -54,27 +54,40 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
         return (priceAndTime.mPrice, priceAndTime.mTime);
     }
 
-    function exchange( bytes32 sourceName, uint sourceAmount, bytes32 destName ) external view override returns (uint value) {
+    function exchange(
+        bytes32 sourceName,
+        uint sourceAmount,
+        bytes32 destName
+    ) external view override returns (uint value) {
         (value, , ) = _exchangeAndPrices(sourceName, sourceAmount, destName);
     }
 
-    function exchangeAndPrices( bytes32 sourceName, uint sourceAmount, bytes32 destName ) external view override
-        returns (uint value, uint sourcePrice, uint destPrice )
+    function exchangeAndPrices(
+        bytes32 sourceName,
+        uint sourceAmount,
+        bytes32 destName
+    )
+        external
+        view
+        override
+        returns (
+            uint value,
+            uint sourcePrice,
+            uint destPrice
+        )
     {
         return _exchangeAndPrices(sourceName, sourceAmount, destName);
     }
 
     function isStale(bytes32 currencyName) external view override returns (bool) {
-        if (currencyName == LUSD ) return false;
+        if (currencyName == LUSD) return false;
         return _getUpdatedTime(currencyName).add(stalePeriod) < now;
     }
-
 
     /* functions */
     function getCurrentRoundId(bytes32 currencyName) external view returns (uint) {
         return mPricesLastRound[currencyName];
     }
-
 
     function setOracle(address _oracle) external onlyAdmin {
         oracle = _oracle;
@@ -87,13 +100,16 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
     }
 
     // 外部调用，更新汇率 oracle是一个地址，从外部用脚本定期调用这个接口
-    function updateAll( bytes32[] calldata currencyNames, uint[] calldata newPrices, uint timeSent ) external onlyOracle returns (bool) {
+    function updateAll(
+        bytes32[] calldata currencyNames,
+        uint[] calldata newPrices,
+        uint timeSent
+    ) external onlyOracle returns (bool) {
         _updateAll(currencyNames, newPrices, timeSent);
     }
 
-    
     function deletePrice(bytes32 currencyName) external onlyOracle {
-        require( _getPrice(currencyName) > 0, "price is zero");
+        require(_getPrice(currencyName) > 0, "price is zero");
 
         delete mPricesStorage[currencyName][mPricesLastRound[currencyName]];
 
@@ -102,16 +118,24 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
         emit PriceDeleted(currencyName);
     }
 
-
-    function _setPrice( bytes32 currencyName, uint256 price, uint256 time ) internal {
+    function _setPrice(
+        bytes32 currencyName,
+        uint256 price,
+        uint256 time
+    ) internal {
         // start from 1
         mPricesLastRound[currencyName]++;
-        mPricesStorage[currencyName][mPricesLastRound[currencyName]] = 
-            PriceData({ mPrice: uint216(price), mTime: uint40(time) });
+        mPricesStorage[currencyName][mPricesLastRound[currencyName]] = PriceData({
+            mPrice: uint216(price),
+            mTime: uint40(time)
+        });
     }
 
-
-    function _updateAll( bytes32[] memory currencyNames, uint[] memory newPrices, uint timeSent ) internal returns (bool) {
+    function _updateAll(
+        bytes32[] memory currencyNames,
+        uint[] memory newPrices,
+        uint timeSent
+    ) internal returns (bool) {
         require(currencyNames.length == newPrices.length, "array length error, not match.");
         require(timeSent < (now + ORACLE_TIME_LIMIT), "Time error");
 
@@ -133,23 +157,32 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
         return true;
     }
 
-
     function _getPriceData(bytes32 currencyName) internal view virtual returns (PriceData memory) {
         return mPricesStorage[currencyName][mPricesLastRound[currencyName]];
     }
 
-     function _getPrice(bytes32 currencyName ) internal view returns (uint256) {
+    function _getPrice(bytes32 currencyName) internal view returns (uint256) {
         PriceData memory priceAndTime = _getPriceData(currencyName);
         return priceAndTime.mPrice;
     }
 
-    function _getUpdatedTime(bytes32 currencyName ) internal view returns (uint256) {
+    function _getUpdatedTime(bytes32 currencyName) internal view returns (uint256) {
         PriceData memory priceAndTime = _getPriceData(currencyName);
         return priceAndTime.mTime;
     }
 
-    function _exchangeAndPrices( bytes32 sourceName, uint sourceAmount, bytes32 destName ) internal view 
-        returns ( uint value, uint sourcePrice, uint destPrice )
+    function _exchangeAndPrices(
+        bytes32 sourceName,
+        uint sourceAmount,
+        bytes32 destName
+    )
+        internal
+        view
+        returns (
+            uint value,
+            uint sourcePrice,
+            uint destPrice
+        )
     {
         sourcePrice = _getPrice(sourceName);
         // If there's no change in the currency, then just return the amount they gave us

--- a/contracts/LnEndAdmin.sol
+++ b/contracts/LnEndAdmin.sol
@@ -4,9 +4,7 @@ pragma solidity ^0.6.12;
 import "./LnAdmin.sol";
 
 contract LnEndAdmin {
-    constructor() public {
-
-    }
+    constructor() public {}
 
     function becomeAdmin(address target) external {
         LnAdmin(target).becomeAdmin();

--- a/contracts/LnExchangeSystem.sol
+++ b/contracts/LnExchangeSystem.sol
@@ -18,69 +18,78 @@ contract LnExchangeSystem is LnAddressCache, LnAdmin {
     bytes32 public constant CONFIG_KEY = ("LnConfig");
     bytes32 public constant REWARD_SYS_KEY = ("LnRewardSystem");
 
-
     ILnAddressStorage mAssets;
     ILnPrices mPrices;
     ILnConfig mConfig;
     address mRewardSys;
 
-    constructor(address _admin) public LnAdmin(_admin ) {
-        
+    constructor(address _admin) public LnAdmin(_admin) {}
+
+    function updateAddressCache(ILnAddressStorage _addressStorage) public override onlyAdmin {
+        mAssets = ILnAddressStorage(_addressStorage.getAddressWithRequire(ASSETS_KEY, ""));
+        mPrices = ILnPrices(_addressStorage.getAddressWithRequire(PRICES_KEY, ""));
+        mConfig = ILnConfig(_addressStorage.getAddressWithRequire(CONFIG_KEY, ""));
+        mRewardSys = _addressStorage.getAddressWithRequire(REWARD_SYS_KEY, "");
+
+        emit CachedAddressUpdated(ASSETS_KEY, address(mAssets));
+        emit CachedAddressUpdated(PRICES_KEY, address(mPrices));
+        emit CachedAddressUpdated(CONFIG_KEY, address(mConfig));
+        emit CachedAddressUpdated(REWARD_SYS_KEY, address(mRewardSys));
     }
 
-
-    function updateAddressCache( ILnAddressStorage _addressStorage ) onlyAdmin public override
-    {
-        mAssets = ILnAddressStorage(_addressStorage.getAddressWithRequire( ASSETS_KEY,"" ));
-        mPrices = ILnPrices(_addressStorage.getAddressWithRequire( PRICES_KEY,"" ));
-        mConfig = ILnConfig(_addressStorage.getAddressWithRequire( CONFIG_KEY,"" ));
-        mRewardSys = _addressStorage.getAddressWithRequire( REWARD_SYS_KEY,"" );
-
-
-        emit CachedAddressUpdated( ASSETS_KEY, address(mAssets) );
-        emit CachedAddressUpdated( PRICES_KEY, address(mPrices) );
-        emit CachedAddressUpdated( CONFIG_KEY, address(mConfig) );
-        emit CachedAddressUpdated( REWARD_SYS_KEY, address(mRewardSys) );
+    function exchange(
+        bytes32 sourceKey,
+        uint sourceAmount,
+        address destAddr,
+        bytes32 destKey
+    ) external {
+        return _exchange(msg.sender, sourceKey, sourceAmount, destAddr, destKey);
     }
 
-
-    function exchange( bytes32 sourceKey, uint sourceAmount, address destAddr, bytes32 destKey  ) external {
-        return _exchange( msg.sender, sourceKey, sourceAmount, destAddr, destKey );
-    }
-
-    function _exchange( address fromAddr, bytes32 sourceKey, uint sourceAmount, address destAddr, bytes32 destKey  ) internal {
-        
-        ILnAsset source = ILnAsset( mAssets.getAddressWithRequire( sourceKey, ""));
-        ILnAsset dest = ILnAsset( mAssets.getAddressWithRequire( destKey, ""));
-        uint destAmount=  mPrices.exchange( sourceKey, sourceAmount, destKey );
-        require( destAmount > 0, "dest amount must > 0" );
+    function _exchange(
+        address fromAddr,
+        bytes32 sourceKey,
+        uint sourceAmount,
+        address destAddr,
+        bytes32 destKey
+    ) internal {
+        ILnAsset source = ILnAsset(mAssets.getAddressWithRequire(sourceKey, ""));
+        ILnAsset dest = ILnAsset(mAssets.getAddressWithRequire(destKey, ""));
+        uint destAmount = mPrices.exchange(sourceKey, sourceAmount, destKey);
+        require(destAmount > 0, "dest amount must > 0");
 
         // 计算手续费
         //uint feeRate = 1 ether / 100; // 0.01
         //  JS设置手续费:  await config.batchSet( ["BTC","CNY"].map(toBytes32), [0.01, 0.01].map(toUnit));
-        uint feeRate = mConfig.getUint( destKey ); // fee rate
+        uint feeRate = mConfig.getUint(destKey); // fee rate
         uint destRecived = destAmount.multiplyDecimal(SafeDecimalMath.unit().sub(feeRate));
-        uint fee = destAmount.sub( destRecived );
+        uint fee = destAmount.sub(destRecived);
 
         // 把手续费转成USD
-        uint feeUsd = mPrices.exchange( destKey, fee, mPrices.LUSD() );
+        uint feeUsd = mPrices.exchange(destKey, fee, mPrices.LUSD());
         // 这里接下来要把手续费放入资金池
-        _addExchangeFee( feeUsd );        
+        _addExchangeFee(feeUsd);
 
         // 先不考虑预言机套利的问题
-        source.burn( fromAddr, sourceAmount );
+        source.burn(fromAddr, sourceAmount);
 
-        dest.mint( destAddr, destRecived );
+        dest.mint(destAddr, destRecived);
 
-        emit ExchangeAsset( fromAddr, sourceKey, sourceAmount, destAddr, destKey, destRecived, feeUsd );
+        emit ExchangeAsset(fromAddr, sourceKey, sourceAmount, destAddr, destKey, destRecived, feeUsd);
     }
 
-    function _addExchangeFee( uint feeUsd ) internal
-    {
-        ILnAsset lusd = ILnAsset( mAssets.getAddressWithRequire( mPrices.LUSD(), ""));
-        lusd.mint( mRewardSys, feeUsd );
+    function _addExchangeFee(uint feeUsd) internal {
+        ILnAsset lusd = ILnAsset(mAssets.getAddressWithRequire(mPrices.LUSD(), ""));
+        lusd.mint(mRewardSys, feeUsd);
     }
-    
-    event ExchangeAsset( address fromAddr, bytes32 sourceKey, uint sourceAmount, address destAddr, bytes32 destKey,  uint destRecived, uint fee );
+
+    event ExchangeAsset(
+        address fromAddr,
+        bytes32 sourceKey,
+        uint sourceAmount,
+        address destAddr,
+        bytes32 destKey,
+        uint destRecived,
+        uint fee
+    );
 }
-

--- a/contracts/SafeDecimalMath.sol
+++ b/contracts/SafeDecimalMath.sol
@@ -23,7 +23,6 @@ library SafeDecimalMath {
     }
 
     function multiplyDecimal(uint x, uint y) internal pure returns (uint) {
-        
         return x.mul(y) / UNIT;
     }
 
@@ -32,7 +31,6 @@ library SafeDecimalMath {
         uint y,
         uint precisionUnit
     ) private pure returns (uint) {
-        
         uint quotientTimesTen = x.mul(y) / (precisionUnit / 10);
 
         if (quotientTimesTen % 10 >= 5) {
@@ -51,7 +49,6 @@ library SafeDecimalMath {
     }
 
     function divideDecimal(uint x, uint y) internal pure returns (uint) {
-        
         return x.mul(UNIT).div(y);
     }
 
@@ -91,4 +88,3 @@ library SafeDecimalMath {
         return quotientTimesTen / 10;
     }
 }
-


### PR DESCRIPTION
Fixes #41.

This PR:

- applies `prettier` to all existing contracts;
- adds a new GitHub Actions workflow for code format validation.