### PR TITLE
Implement fee splitting between reward pool and foundation

### DIFF
--- a/contracts/LnExchangeSystem.sol
+++ b/contracts/LnExchangeSystem.sol
@@ -14,15 +14,29 @@ contract LnExchangeSystem is LnAdminUpgradeable, LnAddressCache {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 
-    bytes32 public constant ASSETS_KEY = ("LnAssetSystem");
-    bytes32 public constant PRICES_KEY = ("LnPrices");
-    bytes32 public constant CONFIG_KEY = ("LnConfig");
-    bytes32 public constant REWARD_SYS_KEY = ("LnRewardSystem");
+    event ExchangeAsset(
+        address fromAddr,
+        bytes32 sourceKey,
+        uint sourceAmount,
+        address destAddr,
+        bytes32 destKey,
+        uint destRecived,
+        uint feeForPool,
+        uint feeForFoundation
+    );
+    event FoundationFeeHolderChanged(address oldHolder, address newHolder);
 
     ILnAddressStorage mAssets;
     ILnPrices mPrices;
     ILnConfig mConfig;
     address mRewardSys;
+    address foundationFeeHolder;
+
+    bytes32 private constant ASSETS_KEY = "LnAssetSystem";
+    bytes32 private constant PRICES_KEY = "LnPrices";
+    bytes32 private constant CONFIG_KEY = "LnConfig";
+    bytes32 private constant REWARD_SYS_KEY = "LnRewardSystem";
+    bytes32 private constant CONFIG_FEE_SPLIT = "FoundationFeeSplit";
 
     function __LnExchangeSystem_init(address _admin) public initializer {
         __LnAdminUpgradeable_init(_admin);
@@ -38,6 +52,16 @@ contract LnExchangeSystem is LnAdminUpgradeable, LnAddressCache {
         emit CachedAddressUpdated(PRICES_KEY, address(mPrices));
         emit CachedAddressUpdated(CONFIG_KEY, address(mConfig));
         emit CachedAddressUpdated(REWARD_SYS_KEY, address(mRewardSys));
+    }
+
+    function setFoundationFeeHolder(address _foundationFeeHolder) public onlyAdmin {
+        require(_foundationFeeHolder != address(0), "LnExchangeSystem: zero address");
+        require(_foundationFeeHolder != foundationFeeHolder, "LnExchangeSystem: foundation fee holder not changed");
+
+        address oldHolder = foundationFeeHolder;
+        foundationFeeHolder = _foundationFeeHolder;
+
+        emit FoundationFeeHolderChanged(oldHolder, foundationFeeHolder);
     }
 
     function exchange(
@@ -61,41 +85,51 @@ contract LnExchangeSystem is LnAdminUpgradeable, LnAddressCache {
         uint destAmount = mPrices.exchange(sourceKey, sourceAmount, destKey);
         require(destAmount > 0, "dest amount must > 0");
 
-        // 计算手续费
-        //uint feeRate = 1 ether / 100; // 0.01
-        //  JS设置手续费:  await config.batchSet( ["BTC","CNY"].map(toBytes32), [0.01, 0.01].map(toUnit));
-        uint feeRate = mConfig.getUint(destKey); // fee rate
+        uint feeRate = mConfig.getUint(destKey);
         uint destRecived = destAmount.multiplyDecimal(SafeDecimalMath.unit().sub(feeRate));
         uint fee = destAmount.sub(destRecived);
 
-        // 把手续费转成USD
-        uint feeUsd = mPrices.exchange(destKey, fee, mPrices.LUSD());
-        // 这里接下来要把手续费放入资金池
-        _addExchangeFee(feeUsd);
+        // Fee going into the pool, to be adjusted based on foundation split
+        uint feeForPoolInUsd = mPrices.exchange(destKey, fee, mPrices.LUSD());
+
+        // Split the fee between pool and foundation when both holder and ratio are set
+        uint256 foundationSplit;
+        if (foundationFeeHolder == address(0)) {
+            foundationSplit = 0;
+        } else {
+            uint256 splitRatio = mConfig.getUint(CONFIG_FEE_SPLIT);
+
+            if (splitRatio == 0) {
+                foundationSplit = 0;
+            } else {
+                foundationSplit = feeForPoolInUsd.multiplyDecimal(splitRatio);
+                feeForPoolInUsd = feeForPoolInUsd.sub(foundationSplit);
+            }
+        }
+
+        ILnAsset lusd =
+            ILnAsset(mAssets.getAddressWithRequire(mPrices.LUSD(), "LnExchangeSystem: failed to get lUSD address"));
+
+        if (feeForPoolInUsd > 0) lusd.mint(mRewardSys, feeForPoolInUsd);
+        if (foundationSplit > 0) lusd.mint(foundationFeeHolder, foundationSplit);
 
         // 先不考虑预言机套利的问题
         source.burn(fromAddr, sourceAmount);
 
         dest.mint(destAddr, destRecived);
 
-        emit ExchangeAsset(fromAddr, sourceKey, sourceAmount, destAddr, destKey, destRecived, feeUsd);
+        emit ExchangeAsset(
+            fromAddr,
+            sourceKey,
+            sourceAmount,
+            destAddr,
+            destKey,
+            destRecived,
+            feeForPoolInUsd,
+            foundationSplit
+        );
     }
-
-    function _addExchangeFee(uint feeUsd) internal {
-        ILnAsset lusd = ILnAsset(mAssets.getAddressWithRequire(mPrices.LUSD(), ""));
-        lusd.mint(mRewardSys, feeUsd);
-    }
-
-    event ExchangeAsset(
-        address fromAddr,
-        bytes32 sourceKey,
-        uint sourceAmount,
-        address destAddr,
-        bytes32 destKey,
-        uint destRecived,
-        uint fee
-    );
 
     // Reserved storage space to allow for layout changes in the future.
-    uint256[46] private __gap;
+    uint256[45] private __gap;
 }

--- a/tests/integration/Exchange.spec.ts
+++ b/tests/integration/Exchange.spec.ts
@@ -1,0 +1,174 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+
+import { expandTo18Decimals, uint256Max } from "../utilities";
+import { deployLinearStack, DeployedStack } from "../utilities/init";
+import { getBlockDateTime } from "../utilities/timeTravel";
+
+describe("Integration | Exchange", function () {
+  let deployer: SignerWithAddress,
+    admin: SignerWithAddress,
+    alice: SignerWithAddress,
+    bob: SignerWithAddress;
+
+  let stack: DeployedStack;
+
+  beforeEach(async function () {
+    [deployer, alice, bob] = await ethers.getSigners();
+    admin = deployer;
+
+    stack = await deployLinearStack(deployer, admin);
+    // Set LINA price to $0.01
+    await stack.lnDefaultPrices.connect(admin).updateAll(
+      [ethers.utils.formatBytes32String("LINA")], // currencyNames
+      [expandTo18Decimals(0.01)], // newPrices
+      (await getBlockDateTime(ethers.provider)).toSeconds() // timeSent
+    );
+
+    // Set lBTC price to $20,000
+    await stack.lnDefaultPrices.connect(admin).updateAll(
+      [ethers.utils.formatBytes32String("lBTC")], // currencyNames
+      [expandTo18Decimals(20_000)], // newPrices
+      (await getBlockDateTime(ethers.provider)).toSeconds() // timeSent
+    );
+
+    // Set BTC exchange fee rate to 1%
+    await stack.lnConfig.connect(admin).setUint(
+      ethers.utils.formatBytes32String("lBTC"), // key
+      expandTo18Decimals(0.01) // value
+    );
+
+    // Mint 1,000,000 LINA to Alice
+    await stack.linaToken
+      .connect(admin)
+      .mint(alice.address, expandTo18Decimals(1_000_000));
+
+    // Alice stakes all LINA
+    await stack.linaToken
+      .connect(alice)
+      .approve(stack.lnCollateralSystem.address, uint256Max);
+    await stack.lnCollateralSystem.connect(alice).Collateral(
+      ethers.utils.formatBytes32String("LINA"), // _currency
+      expandTo18Decimals(1_000_000) // _amount
+    );
+
+    // Alice builds 1,000 lUSD
+    await stack.lnBuildBurnSystem.connect(alice).BuildAsset(
+      expandTo18Decimals(1_000) // amount
+    );
+  });
+
+  it("fee not splitted when fee holder is not set", async () => {
+    // Set fee split ratio to 30%
+    await stack.lnConfig.connect(admin).setUint(
+      ethers.utils.formatBytes32String("FoundationFeeSplit"), // key
+      expandTo18Decimals(0.3) // value
+    );
+
+    // Alice exchanges 500 lUSD for 0.025 lBTC
+    await stack.lnExchangeSystem.connect(alice).exchange(
+      ethers.utils.formatBytes32String("lUSD"), // sourceKey
+      expandTo18Decimals(500), // sourceAmount
+      alice.address, // destAddr
+      ethers.utils.formatBytes32String("lBTC") // destKey
+    );
+
+    // All fees (0.025 * 0.01 * 20000 = 5) go to pool
+    expect(
+      await stack.lusdToken.balanceOf(stack.lnRewardSystem.address)
+    ).to.equal(expandTo18Decimals(5));
+
+    // Proceedings after fees: 500 / 20000 * (1 - 0.01) = 0.02475 BTC
+    expect(await stack.lusdToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(500)
+    );
+    expect(await stack.lbtcToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(0.02475)
+    );
+  });
+
+  it("fee not splitted when split ratio is not set", async () => {
+    // Set fee holder to bob
+    await stack.lnExchangeSystem.connect(admin).setFoundationFeeHolder(
+      bob.address // _foundationFeeHolder
+    );
+
+    // Alice exchanges 500 lUSD for 0.025 lBTC
+    await stack.lnExchangeSystem.connect(alice).exchange(
+      ethers.utils.formatBytes32String("lUSD"), // sourceKey
+      expandTo18Decimals(500), // sourceAmount
+      alice.address, // destAddr
+      ethers.utils.formatBytes32String("lBTC") // destKey
+    );
+
+    // All fees (0.025 * 0.01 * 20000 = 5) go to pool
+    expect(
+      await stack.lusdToken.balanceOf(stack.lnRewardSystem.address)
+    ).to.equal(expandTo18Decimals(5));
+    expect(await stack.lusdToken.balanceOf(bob.address)).to.equal(0);
+
+    // Proceedings after fees: 500 / 20000 * (1 - 0.01) = 0.02475 BTC
+    expect(await stack.lusdToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(500)
+    );
+    expect(await stack.lbtcToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(0.02475)
+    );
+  });
+
+  it("fee splitted to pool and foundation", async () => {
+    // Set fee split ratio to 30%
+    await stack.lnConfig.connect(admin).setUint(
+      ethers.utils.formatBytes32String("FoundationFeeSplit"), // key
+      expandTo18Decimals(0.3) // value
+    );
+
+    // Set fee holder to bob
+    await stack.lnExchangeSystem.connect(admin).setFoundationFeeHolder(
+      bob.address // _foundationFeeHolder
+    );
+
+    // Alice exchanges 500 lUSD for 0.025 lBTC
+    await expect(
+      stack.lnExchangeSystem.connect(alice).exchange(
+        ethers.utils.formatBytes32String("lUSD"), // sourceKey
+        expandTo18Decimals(500), // sourceAmount
+        alice.address, // destAddr
+        ethers.utils.formatBytes32String("lBTC") // destKey
+      )
+    )
+      .to.emit(stack.lnExchangeSystem, "ExchangeAsset")
+      .withArgs(
+        alice.address, // fromAddr
+        ethers.utils.formatBytes32String("lUSD"), // sourceKey
+        expandTo18Decimals(500), // sourceAmount
+        alice.address, // destAddr
+        ethers.utils.formatBytes32String("lBTC"), // destKey
+        expandTo18Decimals(0.02475), // destRecived
+        expandTo18Decimals(3.5), // feeForPool
+        expandTo18Decimals(1.5) // feeForFoundation
+      );
+
+    /**
+     * Fee split:
+     *   Total = 0.025 * 0.01 * 20000 = 5 lUSD
+     *   Foundation = 5 * 0.3 = 1.5 lUSD
+     *   Pool = 5 - 1.5 = 3.5 lUSD
+     */
+    expect(
+      await stack.lusdToken.balanceOf(stack.lnRewardSystem.address)
+    ).to.equal(expandTo18Decimals(3.5));
+    expect(await stack.lusdToken.balanceOf(bob.address)).to.equal(
+      expandTo18Decimals(1.5)
+    );
+
+    // Proceedings after fees: 500 / 20000 * (1 - 0.01) = 0.02475 BTC
+    expect(await stack.lusdToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(500)
+    );
+    expect(await stack.lbtcToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(0.02475)
+    );
+  });
+});


### PR DESCRIPTION
This PR:

- adds support for optionally splitting part of exchange fees to a designated foundation fee holder address in `LnExchangeSystem`;
- adds integration test cases for the split;
- adds `LnExchangeSystem` deployment to `init` test script.