### PR TITLE
Add Linear Vault contracts for token staking

### DIFF
--- a/contracts/LnVaultDynamicInterestPool.sol
+++ b/contracts/LnVaultDynamicInterestPool.sol
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/math/SignedSafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/SafeCastUpgradeable.sol";
+import "./utilities/TransferHelper.sol";
+
+/**
+ * @title LnVaultDynamicInterestPool
+ *
+ * @dev A subscription-based staking pool with subscription amount limits. Reward (interest) rates are set by
+ * the contract owner.
+ */
+contract LnVaultDynamicInterestPool is OwnableUpgradeable {
+    using SafeCastUpgradeable for int256;
+    using SafeCastUpgradeable for uint256;
+    using SafeMathUpgradeable for uint256;
+    using SignedSafeMathUpgradeable for int256;
+    using TransferHelper for address;
+
+    event PoolInitialized(
+        uint256 firstPeriodStartTime,
+        uint256 periodDuration,
+        uint256 totalSubscriptionLimit,
+        uint256 userSubscriptionLimit,
+        address stakeToken,
+        address interestToken
+    );
+    event Subscribed(address indexed user, uint256 indexed periodId, uint256 amount);
+    event Unsubscribed(address indexed user, uint256 indexed periodId, uint256 amount);
+    event PrincipalWithdrawn(address indexed user, uint256 amount);
+    event InterestWithdrawn(
+        address indexed user,
+        uint256 indexed periodId,
+        uint256 principal,
+        uint256 interestRate,
+        uint256 interest
+    );
+    event InterestRateSet(uint256 indexed periodId, uint256 interestRate);
+
+    struct UserData {
+        uint256 subscribedAmount;
+        int256 pendingAmount;
+        uint256 pendingAmountPeriodId;
+        uint256 lastInterestWithdrawalPeriodId;
+        uint256 refundingAmount;
+        uint256 refundPeriodId;
+    }
+
+    uint256 public firstPeriodStartTime;
+    uint256 public periodDuration;
+    uint256 public totalSubscriptionLimit;
+    uint256 public userSubscriptionLimit;
+    address public stakeToken;
+    address public interestToken;
+
+    uint256 public totalSubscribedAmount;
+
+    mapping(address => UserData) public userData;
+    mapping(uint256 => uint256) public interestRates;
+
+    uint256 public constant INTEREST_RATE_UNIT = 10**18;
+
+    function getWithdrawablePrincipal(address user) external view returns (uint256) {
+        UserData memory currentUserData = userData[user];
+
+        if (currentUserData.refundingAmount == 0) return 0;
+
+        uint256 currentPeriodId = getCurrentPeriodId();
+        return currentPeriodId >= currentUserData.refundPeriodId ? currentUserData.refundingAmount : 0;
+    }
+
+    function getWithdrawableInterests(address user)
+        external
+        view
+        returns (
+            uint256 fromPeriodId,
+            uint256 toPeriodId,
+            uint256 amount
+        )
+    {
+        uint256 currentPeriodId = getCurrentPeriodId();
+        UserData memory currentUserData = userData[user];
+
+        // Nothing to withdraw if not subscribed
+        if (currentUserData.subscribedAmount == 0) {
+            return (0, 0, 0);
+        }
+
+        uint256 firstClaimablePeriodId = currentUserData.lastInterestWithdrawalPeriodId + 1;
+
+        uint256 periodCount = 0;
+        uint256 accumulatedInterest = 0;
+
+        for (uint256 periodId = firstClaimablePeriodId; periodId < currentPeriodId; periodId++) {
+            uint256 periodInterestRate = interestRates[periodId];
+            if (periodInterestRate == 0) break;
+
+            uint256 periodPrincipal = currentUserData.subscribedAmount;
+            if (currentUserData.pendingAmountPeriodId > 0 && currentUserData.pendingAmountPeriodId < periodId) {
+                periodPrincipal = periodPrincipal.toInt256().add(currentUserData.pendingAmount).toUint256();
+            }
+
+            periodCount++;
+            accumulatedInterest = accumulatedInterest.add(periodPrincipal.mul(periodInterestRate).div(INTEREST_RATE_UNIT));
+        }
+
+        return
+            periodCount == 0
+                ? (0, 0, 0)
+                : (firstClaimablePeriodId, firstClaimablePeriodId + periodCount - 1, accumulatedInterest);
+    }
+
+    function getCurrentPeriodId() public view returns (uint256) {
+        return block.timestamp < firstPeriodStartTime ? 0 : (block.timestamp - firstPeriodStartTime) / periodDuration + 1;
+    }
+
+    function __LnVaultDynamicInterestPool_init(
+        uint256 _firstPeriodStartTime,
+        uint256 _periodDuration,
+        uint256 _totalSubscriptionLimit,
+        uint256 _userSubscriptionLimit,
+        address _stakeToken,
+        address _interestToken
+    ) public initializer {
+        __Ownable_init();
+
+        require(_firstPeriodStartTime > block.timestamp, "LnVaultDynamicInterestPool: invalid time range");
+        require(_periodDuration > 0, "LnVaultDynamicInterestPool: zero duration");
+        require(_totalSubscriptionLimit > 0, "LnVaultDynamicInterestPool: zero subscription limit");
+        require(_stakeToken != address(0), "LnVaultDynamicInterestPool: zero address");
+        require(_interestToken != address(0), "LnVaultDynamicInterestPool: zero address");
+
+        firstPeriodStartTime = _firstPeriodStartTime;
+        periodDuration = _periodDuration;
+        totalSubscriptionLimit = _totalSubscriptionLimit;
+        userSubscriptionLimit = _userSubscriptionLimit;
+        stakeToken = _stakeToken;
+        interestToken = _interestToken;
+
+        emit PoolInitialized(
+            _firstPeriodStartTime,
+            _periodDuration,
+            _totalSubscriptionLimit,
+            _userSubscriptionLimit,
+            _stakeToken,
+            _interestToken
+        );
+    }
+
+    function subscribe(uint256 amount) external {
+        _subscribe(msg.sender, amount);
+    }
+
+    function unsubscribe(uint256 amount) external {
+        _unsubscribe(msg.sender, amount);
+    }
+
+    function withdrawPrincipal() external {
+        _withdrawPrincipal(msg.sender);
+    }
+
+    function withdrawInterest(uint256 periodId) external {
+        _withdrawInterest(msg.sender, periodId);
+    }
+
+    function withdrawInterests(uint256 fromPeriodId, uint256 toPeriodId) external {
+        require(fromPeriodId > 0 && toPeriodId >= fromPeriodId, "LnVaultDynamicInterestPool: invalid period range");
+
+        for (uint256 periodId = fromPeriodId; periodId <= toPeriodId; periodId++) {
+            _withdrawInterest(msg.sender, periodId);
+        }
+    }
+
+    function setInterestRate(uint256 periodId, uint256 interestRate) external onlyOwner {
+        require(periodId > 0, "LnVaultDynamicInterestPool: invalid period id");
+        require(interestRate > 0, "LnVaultDynamicInterestPool: zero rate");
+
+        require(interestRates[periodId] == 0, "LnVaultDynamicInterestPool: rate already set");
+
+        interestRates[periodId] = interestRate;
+        emit InterestRateSet(periodId, interestRate);
+    }
+
+    function _subscribe(address user, uint256 amount) private {
+        _adjustSubscription(user, amount.toInt256());
+    }
+
+    function _unsubscribe(address user, uint256 amount) private {
+        _adjustSubscription(user, -amount.toInt256());
+    }
+
+    function _adjustSubscription(address user, int256 amount) private {
+        require(amount != 0, "LnVaultDynamicInterestPool: zero amount");
+
+        uint256 currentPeriodId = getCurrentPeriodId();
+        UserData memory currentUserData = userData[user];
+
+        // User didn't have subscription before. Will start earning interest from next period
+        if (amount > 0 && currentUserData.subscribedAmount == 0) {
+            // Only update state if it's different to save gas
+            if (currentUserData.lastInterestWithdrawalPeriodId != currentPeriodId) {
+                userData[user].lastInterestWithdrawalPeriodId = currentPeriodId;
+
+                // Also update the memory copy since we'll need it later
+                currentUserData.lastInterestWithdrawalPeriodId = currentPeriodId;
+            }
+        }
+
+        if (currentUserData.lastInterestWithdrawalPeriodId == currentPeriodId) {
+            // User isn't earning interest for the current period. The amount can be changed directly
+
+            int256 newAmountSigned = currentUserData.subscribedAmount.toInt256().add(amount);
+            require(newAmountSigned >= 0, "LnVaultDynamicInterestPool: insufficient amount");
+
+            uint256 newAmountUnsigned = newAmountSigned.toUint256();
+            require(newAmountUnsigned <= userSubscriptionLimit, "LnVaultDynamicInterestPool: user oversubscribed");
+
+            userData[user].subscribedAmount = newAmountUnsigned;
+        } else {
+            // User already making interest for the current period. Need to maintain the amount and put the changes in pending instead
+
+            // Must settle the already-pending amount first by withdrawing interests
+            require(
+                currentUserData.pendingAmountPeriodId == 0 || currentUserData.pendingAmountPeriodId == currentPeriodId,
+                "LnVaultDynamicInterestPool: amount change pending"
+            );
+
+            int256 newPendingAmount = currentUserData.pendingAmount.add(amount);
+
+            int256 newOverallAmountSigned = newPendingAmount.add(currentUserData.subscribedAmount.toInt256());
+            require(newOverallAmountSigned >= 0, "LnVaultDynamicInterestPool: insufficient amount");
+
+            require(
+                newOverallAmountSigned.toUint256() <= userSubscriptionLimit,
+                "LnVaultDynamicInterestPool: user oversubscribed"
+            );
+
+            userData[user].pendingAmount = newPendingAmount;
+            if (currentUserData.pendingAmountPeriodId != currentPeriodId) {
+                userData[user].pendingAmountPeriodId = currentPeriodId;
+            }
+        }
+
+        totalSubscribedAmount = totalSubscribedAmount.toInt256().add(amount).toUint256();
+        require(totalSubscribedAmount <= totalSubscriptionLimit, "LnVaultDynamicInterestPool: total oversubscribed");
+
+        if (amount > 0) {
+            stakeToken.safeTransferFrom(user, address(this), amount.toUint256());
+
+            emit Subscribed(user, currentPeriodId, amount.toUint256());
+        } else {
+            // Must withdraw previous pending refunds first
+            require(
+                currentUserData.refundPeriodId == currentPeriodId + 1 ||
+                    (currentUserData.refundingAmount == 0 && currentUserData.refundPeriodId == 0),
+                "LnVaultDynamicInterestPool: withdraw pending refund first"
+            );
+
+            userData[user].refundingAmount = currentUserData.refundingAmount.add((-amount).toUint256());
+            if (currentUserData.refundPeriodId == 0) {
+                userData[user].refundPeriodId = currentPeriodId + 1;
+            }
+
+            emit Unsubscribed(user, currentPeriodId, (-amount).toUint256());
+        }
+    }
+
+    function _withdrawPrincipal(address user) private {
+        uint256 currentPeriodId = getCurrentPeriodId();
+        uint256 refundingAmount = userData[user].refundingAmount;
+        uint256 refundPeriodId = userData[user].refundPeriodId;
+
+        require(refundingAmount > 0, "LnVaultDynamicInterestPool: no refund pending");
+        require(currentPeriodId >= refundPeriodId, "LnVaultDynamicInterestPool: refund still pending");
+
+        userData[user].refundingAmount = 0;
+        userData[user].refundPeriodId = 0;
+
+        stakeToken.safeTransfer(user, refundingAmount);
+
+        emit PrincipalWithdrawn(user, refundingAmount);
+    }
+
+    function _withdrawInterest(address user, uint256 periodId) private {
+        uint256 currentPeriodId = getCurrentPeriodId();
+        UserData memory currentUserData = userData[user];
+
+        require(periodId < currentPeriodId, "LnVaultDynamicInterestPool: period not ended");
+        require(
+            periodId == currentUserData.lastInterestWithdrawalPeriodId + 1,
+            "LnVaultDynamicInterestPool: invalid period id"
+        );
+
+        // It should actually be impossible for this to not hold. We're still asserting it here just to be safe.
+        require(
+            currentUserData.pendingAmountPeriodId == 0 || currentUserData.pendingAmountPeriodId >= periodId,
+            "LnVaultDynamicInterestPool: unexpected pending changes"
+        );
+
+        // Mark period as claimed
+        userData[user].lastInterestWithdrawalPeriodId = periodId;
+
+        // No need to retain the amount before pending changes anymore since it was just used for the last time
+        if (currentUserData.pendingAmountPeriodId == periodId) {
+            userData[user].subscribedAmount = currentUserData
+                .subscribedAmount
+                .toInt256()
+                .add(currentUserData.pendingAmount)
+                .toUint256();
+            userData[user].pendingAmount = 0;
+            userData[user].pendingAmountPeriodId = 0;
+        }
+
+        uint256 periodInterestRate = interestRates[periodId];
+        require(periodInterestRate > 0, "LnVaultDynamicInterestPool: interest rate not set");
+
+        uint256 principal = currentUserData.subscribedAmount; // subscribedAmount here is before pending changes settlement (memory copy)
+        uint256 interestPayment = principal.mul(periodInterestRate).div(INTEREST_RATE_UNIT);
+
+        // It's possible that principal is so small that interest is zero
+        if (interestPayment > 0) {
+            interestToken.safeTransfer(user, interestPayment);
+        }
+
+        emit InterestWithdrawn(user, periodId, principal, periodInterestRate, interestPayment);
+    }
+}

--- a/contracts/LnVaultFixedRewardPool.sol
+++ b/contracts/LnVaultFixedRewardPool.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/math/MathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "./utilities/TransferHelper.sol";
+
+/**
+ * @title LnVaultFixedRewardPool
+ *
+ * @dev A token staking pool where a fixed amount of rewards are released every second, and distributed
+ * to pool participants on a pro-rata basis.
+ */
+contract LnVaultFixedRewardPool is OwnableUpgradeable {
+    using MathUpgradeable for uint256;
+    using SafeMathUpgradeable for uint256;
+    using TransferHelper for address;
+
+    event PoolInitialized(uint256 startTime, uint256 rewardPerSecond, address stakeToken, address rewardToken);
+    event Staked(address indexed staker, address token, uint256 amount);
+    event Unstaked(address indexed staker, address token, uint256 amount);
+    event RewardClaimed(address indexed staker, address token, uint256 amount);
+    event RewardPerSecondChanged(uint256 oldRewardPerSecond, uint256 newRewardPerSecond);
+
+    struct UserData {
+        uint256 stakeAmount;
+        uint256 pendingReward;
+        uint256 entryAccuRewardPerShare;
+    }
+
+    // Pool config
+    uint256 public startTime;
+    uint256 public rewardPerSecond;
+    address public stakeToken;
+    address public rewardToken;
+
+    // Pool data
+    uint256 public totalStakeAmount;
+    uint256 public accuRewardPerShare;
+    uint256 public accuRewardLastUpdateTime;
+    mapping(address => UserData) public userData;
+
+    uint256 private constant ACCU_REWARD_MULTIPLIER = 10**20; // Precision loss prevention
+
+    modifier onlyStarted() {
+        require(block.timestamp >= startTime, "LnVaultFixedRewardPool: pool not started");
+        _;
+    }
+
+    function getReward(address staker) external view returns (uint256) {
+        UserData memory currentUserData = userData[staker];
+
+        uint256 latestAccuRewardPerShare =
+            totalStakeAmount > 0
+                ? accuRewardPerShare.add(
+                    block.timestamp.sub(accuRewardLastUpdateTime).mul(rewardPerSecond).mul(ACCU_REWARD_MULTIPLIER).div(
+                        totalStakeAmount
+                    )
+                )
+                : accuRewardPerShare;
+
+        return
+            currentUserData.pendingReward.add(
+                currentUserData.stakeAmount.mul(latestAccuRewardPerShare.sub(currentUserData.entryAccuRewardPerShare)).div(
+                    ACCU_REWARD_MULTIPLIER
+                )
+            );
+    }
+
+    function __LnVaultFixedRewardPool_init(
+        uint256 _startTime,
+        uint256 _rewardPerSecond,
+        address _stakeToken,
+        address _rewardToken
+    ) public initializer {
+        __Ownable_init();
+
+        require(_startTime > block.timestamp, "LnVaultFixedRewardPool: invalid start time");
+        require(_rewardPerSecond > 0, "LnVaultFixedRewardPool: zero reward");
+        require(_stakeToken != address(0), "LnVaultFixedRewardPool: zero address");
+        require(_rewardToken != address(0), "LnVaultFixedRewardPool: zero address");
+
+        startTime = _startTime;
+        rewardPerSecond = _rewardPerSecond;
+        stakeToken = _stakeToken;
+        rewardToken = _rewardToken;
+
+        accuRewardLastUpdateTime = _startTime;
+
+        emit PoolInitialized(_startTime, _rewardPerSecond, _stakeToken, _rewardToken);
+    }
+
+    function stake(uint256 amount) external onlyStarted {
+        _updateAccuReward();
+        _updateStakerReward(msg.sender);
+
+        _stake(msg.sender, amount);
+    }
+
+    function unstake(uint256 amount) external {
+        _updateAccuReward();
+        _updateStakerReward(msg.sender);
+
+        _unstake(msg.sender, amount);
+    }
+
+    function claimReward() external {
+        _updateAccuReward();
+        _updateStakerReward(msg.sender);
+
+        uint256 rewardToClaim = userData[msg.sender].pendingReward;
+        require(rewardToClaim > 0, "LnVaultFixedRewardPool: no reward to claim");
+
+        userData[msg.sender].pendingReward = 0;
+
+        rewardToken.safeTransfer(msg.sender, rewardToClaim);
+
+        emit RewardClaimed(msg.sender, rewardToken, rewardToClaim);
+    }
+
+    function setRewardPerSecond(uint256 newRewardPerSecond) external onlyOwner {
+        // "Settle" rewards up to this block if pool already started
+        if (block.timestamp >= startTime) {
+            _updateAccuReward();
+        }
+
+        uint256 oldRewardPerSecond = rewardPerSecond;
+        rewardPerSecond = newRewardPerSecond;
+
+        emit RewardPerSecondChanged(oldRewardPerSecond, newRewardPerSecond);
+    }
+
+    function _stake(address user, uint256 amount) private {
+        require(amount > 0, "LnVaultFixedRewardPool: cannot stake zero amount");
+
+        userData[user].stakeAmount = userData[user].stakeAmount.add(amount);
+        totalStakeAmount = totalStakeAmount.add(amount);
+
+        stakeToken.safeTransferFrom(user, address(this), amount);
+
+        emit Staked(user, stakeToken, amount);
+    }
+
+    function _unstake(address user, uint256 amount) private {
+        require(amount > 0, "LnVaultFixedRewardPool: cannot unstake zero amount");
+
+        // No sufficiency check required as sub() will throw anyways
+        userData[user].stakeAmount = userData[user].stakeAmount.sub(amount);
+        totalStakeAmount = totalStakeAmount.sub(amount);
+
+        stakeToken.safeTransfer(user, amount);
+
+        emit Unstaked(user, stakeToken, amount);
+    }
+
+    function _updateAccuReward() private {
+        uint256 durationInSeconds = block.timestamp.sub(accuRewardLastUpdateTime);
+
+        // This saves tx cost when being called multiple times in the same block
+        if (durationInSeconds > 0) {
+            // No need to update the rate if no one staked at all
+            if (totalStakeAmount > 0) {
+                accuRewardPerShare = accuRewardPerShare.add(
+                    durationInSeconds.mul(rewardPerSecond).mul(ACCU_REWARD_MULTIPLIER).div(totalStakeAmount)
+                );
+            }
+            accuRewardLastUpdateTime = block.timestamp;
+        }
+    }
+
+    function _updateStakerReward(address staker) private {
+        UserData storage currentUserData = userData[staker];
+
+        uint256 accuDifference = accuRewardPerShare.sub(currentUserData.entryAccuRewardPerShare);
+
+        if (accuDifference > 0) {
+            currentUserData.pendingReward = currentUserData.pendingReward.add(
+                currentUserData.stakeAmount.mul(accuDifference).div(ACCU_REWARD_MULTIPLIER)
+            );
+            currentUserData.entryAccuRewardPerShare = accuRewardPerShare;
+        }
+    }
+}

--- a/contracts/utilities/TransferHelper.sol
+++ b/contracts/utilities/TransferHelper.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @title TransferHelper
+ *
+ * @dev A helper library for calling functions on ERC20 tokens with compatibility for
+ * non-ERC20 compliant contracts like Tether.
+ */
+library TransferHelper {
+    bytes4 private constant TRANSFER_SELECTOR = bytes4(keccak256(bytes("transfer(address,uint256)")));
+    bytes4 private constant APPROVE_SELECTOR = bytes4(keccak256(bytes("approve(address,uint256)")));
+    bytes4 private constant TRANSFERFROM_SELECTOR = bytes4(keccak256(bytes("transferFrom(address,address,uint256)")));
+
+    function safeTransfer(
+        address token,
+        address recipient,
+        uint256 amount
+    ) internal {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(TRANSFER_SELECTOR, recipient, amount));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "TransferHelper: transfer failed");
+    }
+
+    function safeApprove(
+        address token,
+        address spender,
+        uint256 amount
+    ) internal {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(APPROVE_SELECTOR, spender, amount));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "TransferHelper: approve failed");
+    }
+
+    function safeTransferFrom(
+        address token,
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal {
+        (bool success, bytes memory data) =
+            token.call(abi.encodeWithSelector(TRANSFERFROM_SELECTOR, sender, recipient, amount));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "TransferHelper: transferFrom failed");
+    }
+}

--- a/tests/LnVaultDynamicInterestPool.spec.ts
+++ b/tests/LnVaultDynamicInterestPool.spec.ts
@@ -1,0 +1,692 @@
+import { ethers, waffle, upgrades } from "hardhat";
+import { expect, use } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { DateTime, Duration } from "luxon";
+import { expandTo18Decimals, uint256Max } from "./utilities";
+import {
+  getBlockDateTime,
+  mineBlock,
+  setNextBlockTimestamp,
+} from "./utilities/timeTravel";
+
+use(waffle.solidity);
+
+describe("LnVaultDynamicInterestPool", function () {
+  let deployer: SignerWithAddress,
+    alice: SignerWithAddress,
+    bob: SignerWithAddress,
+    charlie: SignerWithAddress;
+
+  let stakeToken: Contract, interestToken: Contract, pool: Contract;
+
+  const periodDuration: Duration = Duration.fromObject({
+    days: 7,
+  });
+
+  let startTime: DateTime;
+
+  let snapshotId: number;
+
+  const multiplyDuration = (count: number): Duration => {
+    return Duration.fromMillis(periodDuration.as("milliseconds") * count);
+  };
+
+  const withdrawInterestWithAssertion = (
+    user: SignerWithAddress,
+    periodId: number,
+    principal: BigNumber | number,
+    interestRate: BigNumber | number,
+    interest: BigNumber | number
+  ): Promise<void> => {
+    return expect(
+      pool.connect(user).withdrawInterest(
+        periodId // periodId
+      )
+    )
+      .to.emit(pool, "InterestWithdrawn")
+      .withArgs(
+        user.address, // user
+        periodId, // periodId
+        principal, // principal
+        interestRate, // interestRate
+        interest // interest
+      )
+      .and.emit(interestToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        user.address, // to
+        interest // amount
+      );
+  };
+
+  const captureSnapshot = async (): Promise<void> => {
+    snapshotId = await ethers.provider.send("evm_snapshot", []);
+  };
+
+  const restoreSnapshot = async (): Promise<void> => {
+    await ethers.provider.send("evm_revert", [snapshotId]);
+  };
+
+  const runAndRevert = async (runner: () => Promise<void>): Promise<void> => {
+    await captureSnapshot();
+    await runner();
+    await restoreSnapshot();
+  };
+
+  const assertWithdrawablePrincipal = (
+    timestamp: DateTime,
+    address: string,
+    amount: number | BigNumber
+  ): Promise<void> => {
+    return runAndRevert(async () => {
+      await mineBlock(ethers.provider, timestamp);
+      expect(await pool.getWithdrawablePrincipal(address)).to.equal(amount);
+    });
+  };
+
+  const assertWithdrawableInterests = (
+    timestamp: DateTime,
+    address: string,
+    fromPeriodId: number,
+    toPeriodId: number,
+    amount: number | BigNumber
+  ): Promise<void> => {
+    return runAndRevert(async () => {
+      await mineBlock(ethers.provider, timestamp);
+      const withdrawables = await pool.getWithdrawableInterests(
+        address // user
+      );
+      expect(withdrawables.fromPeriodId).to.equal(fromPeriodId);
+      expect(withdrawables.toPeriodId).to.equal(toPeriodId);
+      expect(withdrawables.amount).to.equal(amount);
+    });
+  };
+
+  beforeEach(async function () {
+    [deployer, alice, bob, charlie] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const LnVaultDynamicInterestPool = await ethers.getContractFactory(
+      "LnVaultDynamicInterestPool"
+    );
+
+    startTime = (await getBlockDateTime(ethers.provider)).plus({ days: 1 });
+
+    stakeToken = await MockERC20.deploy(
+      "STAKE Token", // _name
+      "STAKE" //Î_symbol
+    );
+    interestToken = await MockERC20.deploy(
+      "INTEREST Token", // _name
+      "INTEREST" // _symbol
+    );
+    pool = await upgrades.deployProxy(
+      LnVaultDynamicInterestPool,
+      [
+        startTime.toSeconds(), // _firstPeriodStartTime
+        periodDuration.as("seconds"), // _periodDuration
+        expandTo18Decimals(2_500), // _totalSubscriptionLimit
+        expandTo18Decimals(1_000), // _userSubscriptionLimit
+        stakeToken.address, // _stakeToken
+        interestToken.address, // _interestToken
+      ],
+      {
+        initializer: "__LnVaultDynamicInterestPool_init",
+      }
+    );
+
+    await interestToken.connect(deployer).mint(
+      pool.address, // account
+      expandTo18Decimals(1_000_000) // amount
+    );
+
+    for (const user of [alice, bob, charlie]) {
+      await stakeToken.connect(deployer).mint(
+        user.address, // account
+        expandTo18Decimals(10_000) // amount
+      );
+      await stakeToken.connect(user).approve(
+        pool.address, // spender
+        uint256Max // amount
+      );
+    }
+  });
+
+  it("cannot subscribe more than user subscription limit", async () => {
+    await expect(
+      pool.connect(alice).subscribe(
+        expandTo18Decimals(1_000).add(1) // amount
+      )
+    ).to.be.revertedWith("LnVaultDynamicInterestPool: user oversubscribed");
+
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await expect(
+      pool.connect(alice).subscribe(
+        1 // amount
+      )
+    ).to.be.revertedWith("LnVaultDynamicInterestPool: user oversubscribed");
+  });
+
+  it("cannot subscribe more than total subscription limit", async () => {
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+    await pool.connect(bob).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await expect(
+      pool.connect(charlie).subscribe(
+        expandTo18Decimals(500).add(1) // amount
+      )
+    ).to.be.revertedWith("LnVaultDynamicInterestPool: total oversubscribed");
+  });
+
+  it("amount subscribed before start should earn interest for the first period", async () => {
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1000) // amount
+    );
+
+    await pool.connect(deployer).setInterestRate(
+      1, // periodId
+      expandTo18Decimals(0.01) // interestRate
+    );
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(periodDuration)
+    );
+
+    // Interest = 1000 * 1% = 10
+    await withdrawInterestWithAssertion(
+      alice, // user
+      1, // periodId
+      expandTo18Decimals(1_000), // principal
+      expandTo18Decimals(0.01), // interestRate
+      expandTo18Decimals(10) // interest
+    );
+  });
+
+  it("amount subscribed in any period should earn interest in the next period", async () => {
+    // In period 2
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(periodDuration)
+    );
+
+    await pool.connect(deployer).setInterestRate(
+      2, // periodId
+      expandTo18Decimals(0.02) // interestRate
+    );
+    await pool.connect(deployer).setInterestRate(
+      3, // periodId
+      expandTo18Decimals(0.03) // interestRate
+    );
+
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1000) // amount
+    );
+
+    // In period 4
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(3))
+    );
+
+    // No interest for period 2
+    await expect(
+      pool.connect(alice).withdrawInterest(
+        2 // periodId
+      )
+    ).to.be.revertedWith("LnVaultDynamicInterestPool: invalid period id");
+
+    // Interest = 1000 * 3% = 30
+    await withdrawInterestWithAssertion(
+      alice, // user
+      3, // periodId
+      expandTo18Decimals(1_000), // principal
+      expandTo18Decimals(0.03), // interestRate
+      expandTo18Decimals(30) // interest
+    );
+  });
+
+  it("subscription amount addition should not affect interests until next period", async () => {
+    await pool.connect(deployer).setInterestRate(
+      2, // periodId
+      expandTo18Decimals(0.02) // interestRate
+    );
+    await pool.connect(deployer).setInterestRate(
+      3, // periodId
+      expandTo18Decimals(0.03) // interestRate
+    );
+
+    // Subscribe 500 in period 1
+    await setNextBlockTimestamp(ethers.provider, startTime);
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(500) // amount
+    );
+
+    // Add 200 in period 2
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(1))
+    );
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(200) // amount
+    );
+
+    await assertWithdrawableInterests(
+      startTime.plus(multiplyDuration(3)),
+      alice.address,
+      2,
+      3,
+      expandTo18Decimals(31)
+    );
+
+    // Period 2 principal excludes 200
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(2))
+    );
+    await withdrawInterestWithAssertion(
+      alice, // user
+      2, // periodId
+      expandTo18Decimals(500), // principal
+      expandTo18Decimals(0.02), // interestRate
+      expandTo18Decimals(10) // interest
+    );
+
+    // Period 3 principal includes 200
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(3))
+    );
+    await withdrawInterestWithAssertion(
+      alice, // user
+      3, // periodId
+      expandTo18Decimals(700), // principal
+      expandTo18Decimals(0.03), // interestRate
+      expandTo18Decimals(21) // interest
+    );
+  });
+
+  it("subscription amount removal should not affect interests until next period", async () => {
+    await pool.connect(deployer).setInterestRate(
+      2, // periodId
+      expandTo18Decimals(0.02) // interestRate
+    );
+    await pool.connect(deployer).setInterestRate(
+      3, // periodId
+      expandTo18Decimals(0.03) // interestRate
+    );
+
+    // Subscribe 500 in period 1
+    await setNextBlockTimestamp(ethers.provider, startTime);
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(500) // amount
+    );
+
+    // Remove 200 in period 2
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(1))
+    );
+    await pool.connect(alice).unsubscribe(
+      expandTo18Decimals(200) // amount
+    );
+
+    await assertWithdrawableInterests(
+      startTime.plus(multiplyDuration(3)),
+      alice.address,
+      2,
+      3,
+      expandTo18Decimals(19)
+    );
+
+    // Period 2 principal still includes 200
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(2))
+    );
+    await withdrawInterestWithAssertion(
+      alice, // user
+      2, // periodId
+      expandTo18Decimals(500), // principal
+      expandTo18Decimals(0.02), // interestRate
+      expandTo18Decimals(10) // interest
+    );
+
+    // Period 3 principal excludes the 200 removed
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(3))
+    );
+    await withdrawInterestWithAssertion(
+      alice, // user
+      3, // periodId
+      expandTo18Decimals(300), // principal
+      expandTo18Decimals(0.03), // interestRate
+      expandTo18Decimals(9) // interest
+    );
+  });
+
+  it("amount unsubscribe before start is locked until the first period starts", async () => {
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    expect(await stakeToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(9_000)
+    );
+    expect(await stakeToken.balanceOf(pool.address)).to.equal(
+      expandTo18Decimals(1_000)
+    );
+
+    await expect(
+      pool.connect(alice).unsubscribe(
+        expandTo18Decimals(1_000) // amount
+      )
+    )
+      .to.emit(pool, "Unsubscribed")
+      .withArgs(
+        alice.address, // user
+        0, // periodId
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await stakeToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(9_000)
+    );
+    expect(await stakeToken.balanceOf(pool.address)).to.equal(
+      expandTo18Decimals(1_000)
+    );
+
+    await assertWithdrawablePrincipal(
+      startTime.minus({
+        seconds: 1,
+      }),
+      alice.address,
+      0
+    );
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.minus({
+        seconds: 1,
+      })
+    );
+    await expect(pool.connect(alice).withdrawPrincipal()).to.be.revertedWith(
+      "LnVaultDynamicInterestPool: refund still pending"
+    );
+
+    await assertWithdrawablePrincipal(
+      startTime,
+      alice.address,
+      expandTo18Decimals(1_000)
+    );
+
+    await setNextBlockTimestamp(ethers.provider, startTime);
+    await expect(pool.connect(alice).withdrawPrincipal())
+      .to.emit(stakeToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        alice.address, // to
+        expandTo18Decimals(1_000) // amount
+      );
+
+    expect(await stakeToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(10_000)
+    );
+    expect(await stakeToken.balanceOf(pool.address)).to.equal(0);
+  });
+
+  it("amount unsubscribe in any period should not be withdrawable until the next period starts", async () => {
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    // Unsubscribe 300 in period 1
+    await setNextBlockTimestamp(ethers.provider, startTime);
+    await pool.connect(alice).unsubscribe(
+      expandTo18Decimals(300) // amount
+    );
+
+    await assertWithdrawablePrincipal(
+      startTime.plus(periodDuration).minus({ seconds: 1 }),
+      alice.address,
+      0
+    );
+
+    // Cannot withdraw before period 1 ends
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(periodDuration).minus({ seconds: 1 })
+    );
+    await expect(pool.connect(alice).withdrawPrincipal()).to.be.revertedWith(
+      "LnVaultDynamicInterestPool: refund still pending"
+    );
+
+    await assertWithdrawablePrincipal(
+      startTime.plus(periodDuration),
+      alice.address,
+      expandTo18Decimals(300)
+    );
+
+    // Can withdraw when period 1 ends
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(periodDuration)
+    );
+    await expect(pool.connect(alice).withdrawPrincipal())
+      .to.emit(stakeToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        alice.address, // to
+        expandTo18Decimals(300) // amount
+      );
+  });
+
+  it("cannot claim interest until period ends", async () => {
+    await pool.connect(deployer).setInterestRate(
+      1, // periodId
+      expandTo18Decimals(0.01) // interestRate
+    );
+
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await assertWithdrawableInterests(
+      startTime.plus(periodDuration).minus({ seconds: 1 }),
+      alice.address,
+      0,
+      0,
+      0
+    );
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(periodDuration).minus({ seconds: 1 })
+    );
+    await expect(
+      pool.connect(alice).withdrawInterest(
+        1 // periodId
+      )
+    ).to.be.revertedWith("LnVaultDynamicInterestPool: period not ended");
+
+    await assertWithdrawableInterests(
+      startTime.plus(periodDuration),
+      alice.address,
+      1,
+      1,
+      expandTo18Decimals(10)
+    );
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(periodDuration)
+    );
+    await withdrawInterestWithAssertion(
+      alice, // user
+      1, // periodId
+      expandTo18Decimals(1_000), // principal
+      expandTo18Decimals(0.01), // interestRate
+      expandTo18Decimals(10) // interest
+    );
+  });
+
+  it("cannot claim interest before rate is set", async () => {
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await assertWithdrawableInterests(
+      startTime.plus(periodDuration),
+      alice.address,
+      0,
+      0,
+      0
+    );
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(periodDuration)
+    );
+    await expect(
+      pool.connect(alice).withdrawInterest(
+        1 // periodId
+      )
+    ).to.be.revertedWith("LnVaultDynamicInterestPool: interest rate not set");
+
+    await pool.connect(deployer).setInterestRate(
+      1, // periodId
+      expandTo18Decimals(0.01) // interestRate
+    );
+
+    await assertWithdrawableInterests(
+      startTime.plus(periodDuration).plus({ minutes: 5 }),
+      alice.address,
+      1,
+      1,
+      expandTo18Decimals(10)
+    );
+
+    await withdrawInterestWithAssertion(
+      alice, // user
+      1, // periodId
+      expandTo18Decimals(1_000), // principal
+      expandTo18Decimals(0.01), // interestRate
+      expandTo18Decimals(10) // interest
+    );
+  });
+
+  it("cannot skip periods when claiming interests", async () => {
+    await pool.connect(deployer).setInterestRate(
+      1, // periodId
+      expandTo18Decimals(0.01) // interestRate
+    );
+    await pool.connect(deployer).setInterestRate(
+      2, // periodId
+      expandTo18Decimals(0.02) // interestRate
+    );
+
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await assertWithdrawableInterests(
+      startTime.plus(multiplyDuration(2)),
+      alice.address,
+      1,
+      2,
+      expandTo18Decimals(30)
+    );
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(2))
+    );
+
+    // Cannot claim period 2 since period 1 is not claimed yet
+    await expect(
+      pool.connect(alice).withdrawInterest(
+        2 // periodId
+      )
+    ).to.be.revertedWith("LnVaultDynamicInterestPool: invalid period id");
+
+    // Can claim period 2 after claiming period 1
+    await withdrawInterestWithAssertion(
+      alice, // user
+      1, // periodId
+      expandTo18Decimals(1_000), // principal
+      expandTo18Decimals(0.01), // interestRate
+      expandTo18Decimals(10) // interest
+    );
+    await withdrawInterestWithAssertion(
+      alice, // user
+      2, // periodId
+      expandTo18Decimals(1_000), // principal
+      expandTo18Decimals(0.02), // interestRate
+      expandTo18Decimals(20) // interest
+    );
+  });
+
+  it("can withdraw interests for multiple periods at once", async () => {
+    await pool.connect(deployer).setInterestRate(
+      1, // periodId
+      expandTo18Decimals(0.01) // interestRate
+    );
+    await pool.connect(deployer).setInterestRate(
+      2, // periodId
+      expandTo18Decimals(0.02) // interestRate
+    );
+
+    await pool.connect(alice).subscribe(
+      expandTo18Decimals(1_000) // amount
+    );
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus(multiplyDuration(2))
+    );
+
+    await expect(
+      pool.connect(alice).withdrawInterests(
+        1, // fromPeriodId
+        2 // toPeriodId
+      )
+    )
+      .to.emit(pool, "InterestWithdrawn")
+      .withArgs(
+        alice.address, // user
+        1, // periodId
+        expandTo18Decimals(1_000), // principal
+        expandTo18Decimals(0.01), // interestRate
+        expandTo18Decimals(10) // interest
+      )
+      .and.emit(interestToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        alice.address, // to
+        expandTo18Decimals(10) // amount
+      )
+      .and.emit(pool, "InterestWithdrawn")
+      .withArgs(
+        alice.address, // user
+        2, // periodId
+        expandTo18Decimals(1_000), // principal
+        expandTo18Decimals(0.02), // interestRate
+        expandTo18Decimals(20) // interest
+      )
+      .and.emit(interestToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        alice.address, // to
+        expandTo18Decimals(10) // amount
+      );
+  });
+});

--- a/tests/LnVaultFixedRewardPool.spec.ts
+++ b/tests/LnVaultFixedRewardPool.spec.ts
@@ -1,0 +1,408 @@
+import { ethers, waffle, upgrades } from "hardhat";
+import { expect, use } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { DateTime } from "luxon";
+import { expandTo18Decimals, uint256Max } from "./utilities";
+import {
+  getBlockDateTime,
+  mineBlock,
+  setNextBlockTimestamp,
+} from "./utilities/timeTravel";
+
+use(waffle.solidity);
+
+describe("LnVaultFixedRewardPool", function () {
+  let deployer: SignerWithAddress,
+    alice: SignerWithAddress,
+    bob: SignerWithAddress;
+
+  let stakeToken: Contract, rewardToken: Contract, pool: Contract;
+
+  let startTime: DateTime;
+
+  let snapshotId: number;
+
+  const assertUserStakeAmount = async (
+    address: string,
+    stakeAmount: number | BigNumber
+  ): Promise<void> => {
+    const userData = await pool.userData(address);
+    expect(userData.stakeAmount).to.equal(stakeAmount);
+  };
+
+  const captureSnapshot = async (): Promise<void> => {
+    snapshotId = await ethers.provider.send("evm_snapshot", []);
+  };
+
+  const restoreSnapshot = async (): Promise<void> => {
+    await ethers.provider.send("evm_revert", [snapshotId]);
+  };
+
+  const runAndRevert = async (runner: () => Promise<void>): Promise<void> => {
+    await captureSnapshot();
+    await runner();
+    await restoreSnapshot();
+  };
+
+  const assertClaimableReward = (
+    timestamp: DateTime,
+    address: string,
+    amount: number | BigNumber
+  ): Promise<void> => {
+    return runAndRevert(async () => {
+      await mineBlock(ethers.provider, timestamp);
+      expect(await pool.getReward(address)).to.equal(amount);
+    });
+  };
+
+  beforeEach(async () => {
+    [deployer, alice, bob] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const LnVaultFixedRewardPool = await ethers.getContractFactory(
+      "LnVaultFixedRewardPool"
+    );
+
+    startTime = (await getBlockDateTime(ethers.provider)).plus({ days: 1 });
+
+    stakeToken = await MockERC20.deploy(
+      "STAKE Token", // _name
+      "STAKE" //Î_symbol
+    );
+    rewardToken = await MockERC20.deploy(
+      "REWARD Token", // _name
+      "REWARD" // _symbol
+    );
+    pool = await upgrades.deployProxy(
+      LnVaultFixedRewardPool,
+      [
+        startTime.toSeconds(), // _startTime
+        expandTo18Decimals(1), // _rewardPerSecond
+        stakeToken.address, // _stakeToken
+        rewardToken.address, // _rewardToken
+      ],
+      {
+        initializer: "__LnVaultFixedRewardPool_init",
+      }
+    );
+
+    await rewardToken.connect(deployer).mint(
+      pool.address, // account
+      expandTo18Decimals(1_000_000) // amount
+    );
+
+    for (const user of [alice, bob]) {
+      await stakeToken.connect(deployer).mint(
+        user.address, // account
+        expandTo18Decimals(10_000) // amount
+      );
+      await stakeToken.connect(user).approve(
+        pool.address, // spender
+        uint256Max // amount
+      );
+    }
+  });
+
+  it("cannot stake before start time", async () => {
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.minus({ seconds: 1 }).toSeconds()
+    );
+    await expect(
+      pool.connect(alice).stake(expandTo18Decimals(1))
+    ).to.be.revertedWith("LnVaultFixedRewardPool: pool not started");
+  });
+
+  it("can stake after start time", async () => {
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+  });
+
+  it("staking should emit Staked event", async () => {
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await expect(pool.connect(alice).stake(expandTo18Decimals(1)))
+      .to.emit(pool, "Staked")
+      .withArgs(
+        alice.address, // staker
+        stakeToken.address, // token
+        expandTo18Decimals(1) // amount
+      );
+  });
+
+  it("unstaking should emit Unstaked event", async () => {
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus({ days: 1 }).toSeconds()
+    );
+    await expect(pool.connect(alice).unstake(expandTo18Decimals(0.1)))
+      .to.emit(pool, "Unstaked")
+      .withArgs(
+        alice.address, // staker
+        stakeToken.address, // token
+        expandTo18Decimals(0.1) // amount
+      );
+  });
+
+  it("cannot unstake when staked amount is zero", async () => {
+    // Cannot unstake without staking first
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await expect(
+      pool.connect(alice).unstake(expandTo18Decimals(1))
+    ).to.be.revertedWith("SafeMath: subtraction overflow");
+
+    // Cannot unstake once all of the staked amount has been unstaked
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+    await pool.connect(alice).unstake(expandTo18Decimals(1));
+    await expect(
+      pool.connect(alice).unstake(expandTo18Decimals(1))
+    ).to.be.revertedWith("SafeMath: subtraction overflow");
+  });
+
+  it("token should be transferred on stake", async () => {
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await expect(pool.connect(alice).stake(expandTo18Decimals(1)))
+      .to.emit(stakeToken, "Transfer")
+      .withArgs(
+        alice.address, // from
+        pool.address, // to
+        expandTo18Decimals(1) // amount
+      );
+
+    expect(await stakeToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(9999)
+    );
+    expect(await stakeToken.balanceOf(pool.address)).to.equal(
+      expandTo18Decimals(1)
+    );
+  });
+
+  it("token should be transferred on unstake", async () => {
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus({ days: 1 }).toSeconds()
+    );
+    await expect(pool.connect(alice).unstake(expandTo18Decimals(0.1)))
+      .to.emit(stakeToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        alice.address, // to
+        expandTo18Decimals(0.1) // amount
+      );
+
+    expect(await stakeToken.balanceOf(alice.address)).to.equal(
+      expandTo18Decimals(9999.1)
+    );
+    expect(await stakeToken.balanceOf(pool.address)).to.equal(
+      expandTo18Decimals(0.9)
+    );
+  });
+
+  it("totalStakeAmount should track total staked amount", async () => {
+    expect(await pool.totalStakeAmount()).to.equal(0);
+
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+    expect(await pool.totalStakeAmount()).to.equal(expandTo18Decimals(1));
+
+    await pool.connect(bob).stake(expandTo18Decimals(3));
+    expect(await pool.totalStakeAmount()).to.equal(expandTo18Decimals(4));
+
+    await pool.connect(alice).unstake(expandTo18Decimals(0.1));
+    expect(await pool.totalStakeAmount()).to.equal(expandTo18Decimals(3.9));
+  });
+
+  it("userData.stakeAmount should track user staked amount", async () => {
+    await assertUserStakeAmount(alice.address, 0);
+    await assertUserStakeAmount(bob.address, 0);
+
+    await setNextBlockTimestamp(ethers.provider, startTime.toSeconds());
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+    await assertUserStakeAmount(alice.address, expandTo18Decimals(1));
+    await assertUserStakeAmount(bob.address, 0);
+
+    await pool.connect(bob).stake(expandTo18Decimals(3));
+    await assertUserStakeAmount(alice.address, expandTo18Decimals(1));
+    await assertUserStakeAmount(bob.address, expandTo18Decimals(3));
+
+    await pool.connect(alice).unstake(expandTo18Decimals(0.1));
+    await assertUserStakeAmount(alice.address, expandTo18Decimals(0.9));
+    await assertUserStakeAmount(bob.address, expandTo18Decimals(3));
+
+    await pool.connect(alice).unstake(expandTo18Decimals(0.9));
+    await assertUserStakeAmount(alice.address, 0);
+    await assertUserStakeAmount(bob.address, expandTo18Decimals(3));
+  });
+
+  it("one staker should earn all rewards", async () => {
+    // Alice stakes 1 day after start
+    await setNextBlockTimestamp(ethers.provider, startTime.plus({ days: 1 }));
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+
+    // The immediate reward amount is zero
+    expect(await pool.getReward(alice.address)).to.equal(0);
+
+    // Should earn all rewards from the first 10 seconds
+    await assertClaimableReward(
+      startTime.plus({ days: 1, seconds: 10 }),
+      alice.address,
+      expandTo18Decimals(10)
+    );
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus({ days: 1, seconds: 10 })
+    );
+    await expect(pool.connect(alice).claimReward())
+      .to.emit(pool, "RewardClaimed")
+      .withArgs(
+        alice.address, // staker
+        rewardToken.address, // token
+        expandTo18Decimals(10) // amount
+      )
+      .and.emit(rewardToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        alice.address, // to
+        expandTo18Decimals(10) // amount
+      );
+
+    // Should earn all rewards from the following 5 seconds
+    await assertClaimableReward(
+      startTime.plus({ days: 1, seconds: 15 }),
+      alice.address,
+      expandTo18Decimals(5)
+    );
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus({ days: 1, seconds: 15 })
+    );
+    await expect(pool.connect(alice).claimReward())
+      .to.emit(pool, "RewardClaimed")
+      .withArgs(
+        alice.address, // staker
+        rewardToken.address, // token
+        expandTo18Decimals(5) // amount
+      )
+      .and.emit(rewardToken, "Transfer")
+      .withArgs(
+        pool.address, // from
+        alice.address, // to
+        expandTo18Decimals(5) // amount
+      );
+  });
+
+  it("proportional reward distribution for multiple stakers", async () => {
+    // Assert helper for the current case
+    const assertRewards = (
+      timestamp: DateTime,
+      aliceReward: number | BigNumber,
+      bobReward: number | BigNumber
+    ): Promise<void> => {
+      return runAndRevert(async () => {
+        await mineBlock(ethers.provider, timestamp);
+        expect(await pool.getReward(alice.address)).to.equal(aliceReward);
+        expect(await pool.getReward(bob.address)).to.equal(bobReward);
+      });
+    };
+
+    // Alice stakes at start time
+    await setNextBlockTimestamp(ethers.provider, startTime);
+    await pool.connect(alice).stake(expandTo18Decimals(1));
+
+    // Only Alice accurs rewards
+    await assertRewards(
+      startTime.plus({ seconds: 10 }),
+      expandTo18Decimals(10),
+      0
+    );
+
+    // Bob stakes so that he takes up 90% of the pool
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus({ seconds: 10 })
+    );
+    await pool.connect(bob).stake(expandTo18Decimals(9));
+
+    // Bob takes 90% from the 10-second period
+    await assertRewards(
+      startTime.plus({ seconds: 20 }),
+      expandTo18Decimals(11),
+      expandTo18Decimals(9)
+    );
+
+    // Bob unstakes such that his share is the same as Alice's
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus({ seconds: 20 })
+    );
+    await pool.connect(bob).unstake(expandTo18Decimals(8));
+
+    // Alice and Bob shares the rewards in half
+    await assertRewards(
+      startTime.plus({ seconds: 30 }),
+      expandTo18Decimals(16),
+      expandTo18Decimals(14)
+    );
+
+    // Bob unstakes everything such that Alice will earn all remaining rewards
+    await setNextBlockTimestamp(
+      ethers.provider,
+      startTime.plus({ seconds: 30 })
+    );
+    await pool.connect(bob).unstake(expandTo18Decimals(1));
+
+    // Alice takes all the rewards
+    await assertRewards(
+      startTime.plus({ seconds: 40 }),
+      expandTo18Decimals(26),
+      expandTo18Decimals(14)
+    );
+
+    // We can't just naively make two transactions for claiming their rewards here
+    // as the block time will be off for 1 second
+    await runAndRevert(async () => {
+      await setNextBlockTimestamp(
+        ethers.provider,
+        startTime.plus({ seconds: 40 })
+      );
+      await expect(pool.connect(alice).claimReward())
+        .to.emit(pool, "RewardClaimed")
+        .withArgs(
+          alice.address, // staker
+          rewardToken.address, // token
+          expandTo18Decimals(26) // amount
+        )
+        .and.emit(rewardToken, "Transfer")
+        .withArgs(
+          pool.address, // from
+          alice.address, // to
+          expandTo18Decimals(26) // amount
+        );
+    });
+    await runAndRevert(async () => {
+      await setNextBlockTimestamp(
+        ethers.provider,
+        startTime.plus({ seconds: 40 })
+      );
+      await expect(pool.connect(bob).claimReward())
+        .to.emit(pool, "RewardClaimed")
+        .withArgs(
+          bob.address, // staker
+          rewardToken.address, // token
+          expandTo18Decimals(14) // amount
+        )
+        .and.emit(rewardToken, "Transfer")
+        .withArgs(
+          pool.address, // from
+          bob.address, // to
+          expandTo18Decimals(14) // amount
+        );
+    });
+  });
+});


### PR DESCRIPTION
This PR adds:

- a contract library `TransferHelper` for performing ERC20 token transfers; and
- a new upgradeable contract `LnVaultDynamicInterestPool` for staking tokens on a subscription-based lock-up format; and
- a new upgradeable contract `LnVaultFixedRewardPool` for staking tokens to earn rewards on a pro-rata basis; and
- test cases for the new contracts.

The newly added contracts will be used for Linear Vault, the token yield farming solution of Linear.