### PR TITLE
Fix #66: fix MaxRedeemable() returning wrong amount

### DIFF
--- a/contracts/interfaces/ILnCollateralSystem.sol
+++ b/contracts/interfaces/ILnCollateralSystem.sol
@@ -10,6 +10,8 @@ interface ILnCollateralSystem {
 
     function MaxRedeemableInUsd(address _user) external view returns (uint256);
 
+    function getFreeCollateralInUsd(address user) external view returns (uint256);
+
     function moveCollateral(
         address fromUser,
         address toUser,


### PR DESCRIPTION
Fixs #66.

This PR:

- deprecates `MaxRedeemableInUsd()` in `LnCollateralSystem` in favor for `getFreeCollateralInUsd()`, which is different only by name; and
- replace the incorrectly implemented `MaxRedeemable()` with `maxRedeemableLina()`, fixing naming and logic at the same time.

After the fix, users without debt can withdraw all their staked collateral without any rounding errors.