### PR TITLE
Add contract for Chainlink integration

### DIFF
--- a/contracts/LnBasePrices.sol
+++ b/contracts/LnBasePrices.sol
@@ -4,6 +4,6 @@ pragma solidity >=0.4.24;
 import "./interfaces/ILnPrices.sol";
 
 abstract contract LnBasePrices is ILnPrices {
-    bytes32 public constant override LINA = "LINA";
+    bytes32 public constant LINA = "LINA";
     bytes32 public constant override LUSD = "lUSD";
 }

--- a/contracts/LnDefaultPrices.sol
+++ b/contracts/LnDefaultPrices.sol
@@ -11,7 +11,7 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
 
     address public oracle;
 
-    uint public override stalePeriod;
+    uint public stalePeriod;
 
     mapping(bytes32 => uint) public mPricesLastRound;
 
@@ -49,7 +49,7 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
         return _getPrice(currencyName);
     }
 
-    function getPriceAndUpdatedTime(bytes32 currencyName) external view override returns (uint price, uint time) {
+    function getPriceAndUpdatedTime(bytes32 currencyName) external view returns (uint price, uint time) {
         PriceData memory priceAndTime = _getPriceData(currencyName);
         return (priceAndTime.mPrice, priceAndTime.mTime);
     }
@@ -69,7 +69,6 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
     )
         external
         view
-        override
         returns (
             uint value,
             uint sourcePrice,
@@ -79,7 +78,7 @@ contract LnDefaultPrices is LnAdminUpgradeable, LnBasePrices {
         return _exchangeAndPrices(sourceName, sourceAmount, destName);
     }
 
-    function isStale(bytes32 currencyName) external view override returns (bool) {
+    function isStale(bytes32 currencyName) external view returns (bool) {
         if (currencyName == LUSD) return false;
         return _getUpdatedTime(currencyName).add(stalePeriod) < now;
     }

--- a/contracts/LnOracleRouter.sol
+++ b/contracts/LnOracleRouter.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/SafeCastUpgradeable.sol";
+import "./interfaces/IBandProtocolOracle.sol";
+import "./interfaces/IChainlinkOracle.sol";
+import "./interfaces/ILnPrices.sol";
+import "./upgradeable/LnAdminUpgradeable.sol";
+import "./SafeDecimalMath.sol";
+
+/**
+ * @title LnOracleRouter
+ *
+ * @dev A contract for providing Linear contracts with access to asset prices from multiple data
+ * oracles including Chainlink and Band Protocol.
+ */
+contract LnOracleRouter is LnAdminUpgradeable, ILnPrices {
+    using SafeCastUpgradeable for int256;
+    using SafeDecimalMath for uint256;
+    using SafeMathUpgradeable for uint256;
+
+    event GlobalStalePeriodUpdated(uint256 oldStalePeriod, uint256 newStalePeriod);
+    event StalePeriodOverrideUpdated(bytes32 currencyKey, uint256 oldStalePeriod, uint256 newStalePeriod);
+    event ChainlinkOracleAdded(bytes32 currencyKey, address oracle);
+    event BandOracleAdded(bytes32 currencyKey, string bandCurrencyKey, address oracle);
+    event OracleRemoved(bytes32 currencyKey, address oracle);
+
+    struct OracleSettings {
+        uint8 oracleType;
+        address oracleAddress;
+    }
+
+    uint256 public globalStalePeriod;
+    mapping(bytes32 => uint256) public stalePeriodOverrides;
+    mapping(bytes32 => OracleSettings) public oracleSettings;
+    mapping(bytes32 => string) public linearCurrencyKeysToBandCurrencyKeys;
+
+    bytes32 public constant override LUSD = "lUSD";
+
+    uint8 public constant ORACLE_TYPE_CHAINLINK = 1;
+    uint8 public constant ORACLE_TYPE_BAND = 2;
+
+    uint8 private constant OUTPUT_PRICE_DECIMALS = 18;
+
+    function getPrice(bytes32 currencyKey) external view override returns (uint256) {
+        (uint256 price, ) = _getPriceData(currencyKey);
+        return price;
+    }
+
+    function getPriceAndUpdatedTime(bytes32 currencyKey) external view returns (uint256 price, uint256 time) {
+        (price, time) = _getPriceData(currencyKey);
+    }
+
+    function isPriceStaled(bytes32 currencyKey) external view returns (bool) {
+        if (currencyKey == LUSD) return false;
+        (, uint256 time) = _getPriceData(currencyKey);
+        return _isUpdateTimeStaled(time, getStalePeriodForCurrency(currencyKey));
+    }
+
+    function exchange(
+        bytes32 sourceKey,
+        uint sourceAmount,
+        bytes32 destKey
+    ) external view override returns (uint256) {
+        if (sourceKey == destKey) return sourceAmount;
+
+        (uint256 sourcePrice, uint256 sourceTime) = _getPriceData(sourceKey);
+        (uint256 destPrice, uint256 destTime) = _getPriceData(destKey);
+
+        require(
+            !_isUpdateTimeStaled(sourceTime, getStalePeriodForCurrency(sourceKey)) &&
+                !_isUpdateTimeStaled(destTime, getStalePeriodForCurrency(destKey)),
+            "LnOracleRouter: staled price data"
+        );
+
+        return sourceAmount.multiplyDecimalRound(sourcePrice).divideDecimalRound(destPrice);
+    }
+
+    function getStalePeriodForCurrency(bytes32 currencyKey) public view returns (uint256) {
+        uint256 overridenPeriod = stalePeriodOverrides[currencyKey];
+        return overridenPeriod == 0 ? globalStalePeriod : overridenPeriod;
+    }
+
+    function __LnOracleRouter_init(address _admin) public initializer {
+        __LnAdminUpgradeable_init(_admin);
+    }
+
+    function setGlobalStalePeriod(uint256 newStalePeriod) external onlyAdmin {
+        uint256 oldStalePeriod = globalStalePeriod;
+        globalStalePeriod = newStalePeriod;
+        emit GlobalStalePeriodUpdated(oldStalePeriod, newStalePeriod);
+    }
+
+    function setStalePeriodOverride(bytes32 currencyKey, uint256 newStalePeriod) external onlyAdmin {
+        uint256 oldStalePeriod = stalePeriodOverrides[currencyKey];
+        stalePeriodOverrides[currencyKey] = newStalePeriod;
+        emit StalePeriodOverrideUpdated(currencyKey, oldStalePeriod, newStalePeriod);
+    }
+
+    function addChainlinkOracle(
+        bytes32 currencyKey,
+        address oracleAddress,
+        bool removeExisting
+    ) external onlyAdmin {
+        _addChainlinkOracle(currencyKey, oracleAddress, removeExisting);
+    }
+
+    function addChainlinkOracles(
+        bytes32[] calldata currencyKeys,
+        address[] calldata oracleAddresses,
+        bool removeExisting
+    ) external onlyAdmin {
+        require(currencyKeys.length == oracleAddresses.length, "LnOracleRouter: array length mismatch");
+
+        for (uint256 ind = 0; ind < currencyKeys.length; ind++) {
+            _addChainlinkOracle(currencyKeys[ind], oracleAddresses[ind], removeExisting);
+        }
+    }
+
+    function addBandOracle(
+        bytes32 currencyKey,
+        string calldata bandCurrencyKey,
+        address oracleAddress,
+        bool removeExisting
+    ) external onlyAdmin {
+        _addBandOracle(currencyKey, bandCurrencyKey, oracleAddress, removeExisting);
+    }
+
+    function addBandOracles(
+        bytes32[] calldata currencyKeys,
+        string[] calldata bandCurrencyKeys,
+        address[] calldata oracleAddresses,
+        bool removeExisting
+    ) external onlyAdmin {
+        require(
+            currencyKeys.length == bandCurrencyKeys.length && bandCurrencyKeys.length == oracleAddresses.length,
+            "LnOracleRouter: array length mismatch"
+        );
+
+        for (uint256 ind = 0; ind < currencyKeys.length; ind++) {
+            _addBandOracle(currencyKeys[ind], bandCurrencyKeys[ind], oracleAddresses[ind], removeExisting);
+        }
+    }
+
+    function removeOracle(bytes32 currencyKey) external onlyAdmin {
+        _removeOracle(currencyKey);
+    }
+
+    function _addChainlinkOracle(
+        bytes32 currencyKey,
+        address oracleAddress,
+        bool removeExisting
+    ) private {
+        require(currencyKey != bytes32(0), "LnOracleRouter: empty currency key");
+        require(oracleAddress != address(0), "LnOracleRouter: empty oracle address");
+
+        if (oracleSettings[currencyKey].oracleAddress != address(0)) {
+            require(removeExisting, "LnOracleRouter: oracle already exists");
+            _removeOracle(currencyKey);
+        }
+
+        oracleSettings[currencyKey] = OracleSettings({oracleType: ORACLE_TYPE_CHAINLINK, oracleAddress: oracleAddress});
+
+        emit ChainlinkOracleAdded(currencyKey, oracleAddress);
+    }
+
+    function _addBandOracle(
+        bytes32 currencyKey,
+        string calldata bandCurrencyKey,
+        address oracleAddress,
+        bool removeExisting
+    ) private {
+        require(currencyKey != bytes32(0), "LnOracleRouter: empty currency key");
+        require(bytes(bandCurrencyKey).length != 0, "LnOracleRouter: empty band currency key");
+        require(oracleAddress != address(0), "LnOracleRouter: empty oracle address");
+
+        if (oracleSettings[currencyKey].oracleAddress != address(0)) {
+            require(removeExisting, "LnOracleRouter: oracle already exists");
+            _removeOracle(currencyKey);
+        }
+
+        oracleSettings[currencyKey] = OracleSettings({oracleType: ORACLE_TYPE_BAND, oracleAddress: oracleAddress});
+        linearCurrencyKeysToBandCurrencyKeys[currencyKey] = bandCurrencyKey;
+
+        emit BandOracleAdded(currencyKey, bandCurrencyKey, oracleAddress);
+    }
+
+    function _removeOracle(bytes32 currencyKey) private {
+        OracleSettings memory settings = oracleSettings[currencyKey];
+        require(settings.oracleAddress != address(0), "LnOracleRouter: oracle not found");
+
+        delete oracleSettings[currencyKey];
+
+        if (settings.oracleType == ORACLE_TYPE_BAND) {
+            delete linearCurrencyKeysToBandCurrencyKeys[currencyKey];
+        }
+
+        emit OracleRemoved(currencyKey, settings.oracleAddress);
+    }
+
+    function _getPriceData(bytes32 currencyKey) private view returns (uint256 price, uint256 updateTime) {
+        if (currencyKey == LUSD) return (SafeDecimalMath.unit(), block.timestamp);
+
+        OracleSettings memory settings = oracleSettings[currencyKey];
+        require(settings.oracleAddress != address(0), "LnOracleRouter: oracle not set");
+
+        if (settings.oracleType == ORACLE_TYPE_CHAINLINK) {
+            (, int256 rawAnswer, , uint256 rawUpdateTime, ) = IChainlinkOracle(settings.oracleAddress).latestRoundData();
+
+            uint8 oraclePriceDecimals = IChainlinkOracle(settings.oracleAddress).decimals();
+            if (oraclePriceDecimals == OUTPUT_PRICE_DECIMALS) {
+                price = rawAnswer.toUint256();
+            } else if (oraclePriceDecimals > OUTPUT_PRICE_DECIMALS) {
+                // Too many decimals
+                price = rawAnswer.toUint256().div(10**(oraclePriceDecimals - OUTPUT_PRICE_DECIMALS));
+            } else {
+                // Too few decimals
+                price = rawAnswer.toUint256().mul(10**(OUTPUT_PRICE_DECIMALS - oraclePriceDecimals));
+            }
+
+            updateTime = rawUpdateTime;
+        } else if (settings.oracleType == ORACLE_TYPE_BAND) {
+            IBandProtocolOracle.ReferenceData memory priceRes =
+                IBandProtocolOracle(settings.oracleAddress).getReferenceData(
+                    linearCurrencyKeysToBandCurrencyKeys[currencyKey],
+                    "USD"
+                );
+
+            price = priceRes.rate;
+            updateTime = priceRes.lastUpdatedBase;
+        } else {
+            require(false, "LnOracleRouter: unknown oracle type");
+        }
+    }
+
+    function _isUpdateTimeStaled(uint256 updateTime, uint256 stalePeriod) private view returns (bool) {
+        return updateTime.add(stalePeriod) < block.timestamp;
+    }
+}

--- a/contracts/interfaces/IChainlinkOracle.sol
+++ b/contracts/interfaces/IChainlinkOracle.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.12 <0.8.0;
+
+interface IChainlinkOracle {
+    function decimals() external view returns (uint8);
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}

--- a/contracts/interfaces/ILnPrices.sol
+++ b/contracts/interfaces/ILnPrices.sol
@@ -1,43 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.24;
 
-// a facade for prices fetch from oracles
 interface ILnPrices {
-    // get price for a currency
-    function getPrice(bytes32 currencyName) external view returns (uint);
+    function getPrice(bytes32 currencyKey) external view returns (uint);
 
-    // get price and updated time for a currency
-    function getPriceAndUpdatedTime(bytes32 currencyName) external view returns (uint price, uint time);
-
-    // is the price is stale
-    function isStale(bytes32 currencyName) external view returns (bool);
-
-    // the defined stale time
-    function stalePeriod() external view returns (uint);
-
-    // exchange amount of source currenty for some dest currency, also get source and dest curreny price
     function exchange(
-        bytes32 sourceName,
+        bytes32 sourceKey,
         uint sourceAmount,
-        bytes32 destName
+        bytes32 destKey
     ) external view returns (uint);
 
-    // exchange amount of source currenty for some dest currency
-    function exchangeAndPrices(
-        bytes32 sourceName,
-        uint sourceAmount,
-        bytes32 destName
-    )
-        external
-        view
-        returns (
-            uint value,
-            uint sourcePrice,
-            uint destPrice
-        );
-
-    // price names
     function LUSD() external view returns (bytes32);
-
-    function LINA() external view returns (bytes32);
 }


### PR DESCRIPTION
This PR adds a new contract `LnOracleRouter` for reading asset prices. Compared to `BandProtocol`, the existing contract used for this purpose, the new contract:

- supports both Chainlink and Band Protocol oracles; and
- natively supports atomically switching from one oracle provider to another without the help of external wrapper contracts; and
- allows setting different stale periods for different currencies; and
- removes unused code related to proprietary oracle.

Test cases haven't been written yet, and will be submitted with another PR at a later time.