### PR TITLE
Fix Chainlink answer calculation overflow in LnOracleRouter

### DIFF
--- a/contracts/LnOracleRouter.sol
+++ b/contracts/LnOracleRouter.sol
@@ -214,10 +214,10 @@ contract LnOracleRouter is LnAdminUpgradeable, ILnPrices {
                 price = rawAnswer.toUint256();
             } else if (oraclePriceDecimals > OUTPUT_PRICE_DECIMALS) {
                 // Too many decimals
-                price = rawAnswer.toUint256().div(10**(oraclePriceDecimals - OUTPUT_PRICE_DECIMALS));
+                price = rawAnswer.toUint256().div(10**uint256(oraclePriceDecimals - OUTPUT_PRICE_DECIMALS));
             } else {
                 // Too few decimals
-                price = rawAnswer.toUint256().mul(10**(OUTPUT_PRICE_DECIMALS - oraclePriceDecimals));
+                price = rawAnswer.toUint256().mul(10**uint256(OUTPUT_PRICE_DECIMALS - oraclePriceDecimals));
             }
 
             updateTime = rawUpdateTime;

--- a/contracts/mock/MockChainlinkAggregator.sol
+++ b/contracts/mock/MockChainlinkAggregator.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.12;
+
+import "../interfaces/IChainlinkOracle.sol";
+
+contract MockChainlinkAggregator is IChainlinkOracle {
+    uint8 public _decimals;
+
+    uint80 public _roundId;
+    int256 public _answer;
+    uint256 public _startedAt;
+    uint256 public _updatedAt;
+    uint80 public _answeredInRound;
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        roundId = _roundId;
+        answer = _answer;
+        startedAt = _startedAt;
+        updatedAt = _updatedAt;
+        answeredInRound = _answeredInRound;
+    }
+
+    function setDecimals(uint8 newDecimals) external {
+        _decimals = newDecimals;
+    }
+
+    function setLatestRoundData(
+        uint80 newRoundId,
+        int256 newAnswer,
+        uint256 newStartedAt,
+        uint256 newUpdatedAt,
+        uint80 newAnsweredInRound
+    ) external {
+        _roundId = newRoundId;
+        _answer = newAnswer;
+        _startedAt = newStartedAt;
+        _updatedAt = newUpdatedAt;
+        _answeredInRound = newAnsweredInRound;
+    }
+}

--- a/tests/LnOracleRouter.spec.ts
+++ b/tests/LnOracleRouter.spec.ts
@@ -1,0 +1,98 @@
+import { ethers, upgrades, waffle } from "hardhat";
+import { expect, use } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { formatBytes32String } from "ethers/lib/utils";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expandTo18Decimals, expandToNDecimals } from "./utilities";
+
+use(waffle.solidity);
+
+describe("LnOracleRouter", function () {
+  let deployer: SignerWithAddress, admin: SignerWithAddress;
+
+  let oracleRouter: Contract, chainlinkAggregator: Contract;
+
+  const assertPriceAndUpdateTime = async (
+    currency: string,
+    price: number | BigNumber,
+    upateTime: number | BigNumber
+  ): Promise<void> => {
+    const priceAndUpdateTime = await oracleRouter.getPriceAndUpdatedTime(
+      formatBytes32String(currency) // currencyKey
+    );
+    expect(priceAndUpdateTime.price).to.equal(price);
+    expect(priceAndUpdateTime.time).to.equal(upateTime);
+  };
+
+  beforeEach(async function () {
+    [deployer, admin] = await ethers.getSigners();
+
+    const SafeDecimalMath = await ethers.getContractFactory("SafeDecimalMath");
+    const safeDecimalMath = await SafeDecimalMath.deploy();
+
+    const LnOracleRouter = await ethers.getContractFactory("LnOracleRouter", {
+      signer: deployer,
+      libraries: {
+        "contracts/SafeDecimalMath.sol:SafeDecimalMath":
+          safeDecimalMath.address,
+      },
+    });
+    const MockChainlinkAggregator = await ethers.getContractFactory(
+      "MockChainlinkAggregator"
+    );
+
+    oracleRouter = await upgrades.deployProxy(
+      LnOracleRouter,
+      [
+        admin.address, // _admin
+      ],
+      {
+        initializer: "__LnOracleRouter_init",
+        unsafeAllowLinkedLibraries: true,
+      }
+    );
+    chainlinkAggregator = await MockChainlinkAggregator.deploy();
+
+    // Set token "LINK" to use Chainlink
+    await oracleRouter.connect(admin).addChainlinkOracle(
+      formatBytes32String("LINK"), // currencyKey
+      chainlinkAggregator.address, // oracleAddress
+      false // removeExisting
+    );
+  });
+
+  it("should get result in 18 decimals regardless of Chainlink aggregator precision", async () => {
+    // 8 decimals
+    await chainlinkAggregator.setDecimals(8);
+    await chainlinkAggregator.setLatestRoundData(
+      1, // newRoundId
+      expandToNDecimals(10, 8), // newAnswer
+      100, // newStartedAt
+      200, // newUpdatedAt
+      1 // newAnsweredInRound
+    );
+    await assertPriceAndUpdateTime("LINK", expandTo18Decimals(10), 200);
+
+    // 18 decimals
+    await chainlinkAggregator.setDecimals(18);
+    await chainlinkAggregator.setLatestRoundData(
+      1, // newRoundId
+      expandToNDecimals(10, 18), // newAnswer
+      100, // newStartedAt
+      200, // newUpdatedAt
+      1 // newAnsweredInRound
+    );
+    await assertPriceAndUpdateTime("LINK", expandTo18Decimals(10), 200);
+
+    // 20 decimals
+    await chainlinkAggregator.setDecimals(20);
+    await chainlinkAggregator.setLatestRoundData(
+      1, // newRoundId
+      expandToNDecimals(10, 20), // newAnswer
+      100, // newStartedAt
+      200, // newUpdatedAt
+      1 // newAnsweredInRound
+    );
+    await assertPriceAndUpdateTime("LINK", expandTo18Decimals(10), 200);
+  });
+});

--- a/tests/utilities/index.ts
+++ b/tests/utilities/index.ts
@@ -9,7 +9,7 @@ export function expandTo18Decimals(num: number): BigNumber {
   return expandToNDecimals(num, 18);
 }
 
-function expandToNDecimals(num: number, n: number): BigNumber {
+export function expandToNDecimals(num: number, n: number): BigNumber {
   let bigNum = new Big(num);
 
   while (!bigNum.round(0, RoundingMode.RoundDown).eq(bigNum)) {


### PR DESCRIPTION
This issue causes Chainlink price answers to always be zero when aggregator `decimals` is less than `16`.