### PR TITLE
feat: use a different ratio for liquidation mark removal

### DIFF
--- a/contracts/LnLiquidation.sol
+++ b/contracts/LnLiquidation.sol
@@ -89,6 +89,7 @@ contract LnLiquidation is LnAdminUpgradeable {
     bytes32 public constant LIQUIDATION_RATIO_KEY = "LiquidationRatio";
     bytes32 public constant LIQUIDATION_DELAY_KEY = "LiquidationDelay";
     bytes32 public constant BUILD_RATIO_KEY = "BuildRatio";
+    bytes32 public constant LIQUIDATION_MARK_REMOVAL_RATIO_KEY = "LiquidationMarkRemoveRatio";
 
     function isPositionMarkedAsUndercollateralized(address user) public view returns (bool) {
         return undercollateralizationMarks[user].timestamp > 0;
@@ -153,8 +154,8 @@ contract LnLiquidation is LnAdminUpgradeable {
 
         // Can only remove mark if C ratio is restored to issuance ratio
         EvalUserPositionResult memory evalResult = evalUserPostion(user);
-        uint256 issuanceRatio = lnConfig.getUint(BUILD_RATIO_KEY);
-        require(evalResult.collateralizationRatio <= issuanceRatio, "LnLiquidation: still undercollateralized");
+        uint256 markRemoveRatio = lnConfig.getUint(LIQUIDATION_MARK_REMOVAL_RATIO_KEY);
+        require(evalResult.collateralizationRatio <= markRemoveRatio, "LnLiquidation: mark removal ratio violation");
 
         delete undercollateralizationMarks[user];
 

--- a/tests/integration/Liquidation.spec.ts
+++ b/tests/integration/Liquidation.spec.ts
@@ -216,17 +216,17 @@ describe("Integration | Liquidation", function () {
       .connect(bob)
       .markPositionAsUndercollateralized(alice.address);
 
-    // LINA price goes to $0.099. Alice cannot remove mark
-    await setLinaPrice(0.099);
+    // LINA price goes to $0.089. Alice cannot remove mark
+    await setLinaPrice(0.089);
 
     await expect(
       stack.lnLiquidation
         .connect(alice)
         .removeUndercollateralizationMark(alice.address)
-    ).to.be.revertedWith("LnLiquidation: still undercollateralized");
+    ).to.be.revertedWith("LnLiquidation: mark removal ratio violation");
 
-    // LINA price goes to $0.1. Alice can now remove mark
-    await setLinaPrice(0.1);
+    // LINA price goes to $0.09. Alice can now remove mark
+    await setLinaPrice(0.09);
     await expect(
       stack.lnLiquidation
         .connect(alice)

--- a/tests/utilities/init.ts
+++ b/tests/utilities/init.ts
@@ -6,7 +6,7 @@
 
 import { Duration } from "luxon";
 import { ethers, upgrades } from "hardhat";
-import { Contract } from "ethers";
+import { BigNumber, Contract } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 
 import { expandTo18Decimals, zeroAddress } from ".";
@@ -252,6 +252,10 @@ export const deployLinearStack = async (
     {
       key: "BuildRatio",
       value: expandTo18Decimals(0.2),
+    },
+    {
+      key: "LiquidationMarkRemoveRatio",
+      value: BigNumber.from("222222222222222222"),
     },
     {
       key: "LiquidationRatio",


### PR DESCRIPTION
Currently, the mark removal process validates that the user's collateralization ratio is at least `BuildRatio`. This PR changes to use a new config item `LiquidationMarkRemoveRatio`.