### PR TITLE
feat: use wormhole for `LnErc20Bridge`

### DIFF
--- a/contracts/interfaces/IWormhole.sol
+++ b/contracts/interfaces/IWormhole.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.12 <0.8.0;
+pragma abicoder v2;
+
+interface IWormhole {
+    struct VM {
+        uint8 version;
+        uint32 timestamp;
+        uint32 nonce;
+        uint16 emitterChainId;
+        bytes32 emitterAddress;
+        uint64 sequence;
+        uint8 consistencyLevel;
+        bytes payload;
+        uint32 guardianSetIndex;
+        Signature[] signatures;
+        bytes32 hash;
+    }
+
+    struct Signature {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        uint8 guardianIndex;
+    }
+
+    function parseAndVerifyVM(bytes calldata encodedVM)
+        external
+        view
+        returns (
+            VM memory vm,
+            bool valid,
+            string memory reason
+        );
+
+    function publishMessage(
+        uint32 nonce,
+        bytes memory payload,
+        uint8 consistencyLevel
+    ) external payable returns (uint64 sequence);
+}

--- a/contracts/mock/MockWormhole.sol
+++ b/contracts/mock/MockWormhole.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "../interfaces/IWormhole.sol";
+
+contract MockWormhole is IWormhole {
+    struct VmValues {
+        uint16 emitterChainId;
+        bytes32 emitterAddress;
+        bytes payload;
+    }
+
+    uint64 public nextSequence;
+    bytes public lastPayload;
+
+    VmValues public vmToReturn;
+    bool public shouldFailVerification;
+
+    function parseAndVerifyVM(bytes calldata encodedVM)
+        external
+        view
+        override
+        returns (
+            VM memory vm,
+            bool valid,
+            string memory reason
+        )
+    {
+        return (
+            IWormhole.VM({
+                version: 0,
+                timestamp: 0,
+                nonce: 0,
+                emitterChainId: vmToReturn.emitterChainId,
+                emitterAddress: vmToReturn.emitterAddress,
+                sequence: 0,
+                consistencyLevel: 0,
+                payload: vmToReturn.payload,
+                guardianSetIndex: 0,
+                signatures: new IWormhole.Signature[](0),
+                hash: bytes32(0)
+            }),
+            !shouldFailVerification,
+            ""
+        );
+    }
+
+    function publishMessage(
+        uint32 nonce,
+        bytes memory payload,
+        uint8 consistencyLevel
+    ) external payable override returns (uint64 sequence) {
+        nextSequence += 1;
+        lastPayload = payload;
+
+        return (nextSequence - 1);
+    }
+
+    function setVmToReturn(
+        uint16 emitterChainId,
+        bytes32 emitterAddress,
+        bytes calldata payload
+    ) external {
+        vmToReturn = VmValues({emitterChainId: emitterChainId, emitterAddress: emitterAddress, payload: payload});
+    }
+
+    function setShouldFailVerification(bool newValue) external {
+        shouldFailVerification = newValue;
+    }
+}

--- a/tests/LnErc20Bridge.spec.ts
+++ b/tests/LnErc20Bridge.spec.ts
@@ -1,14 +1,16 @@
 import { ethers, waffle } from "hardhat";
 import { expect, use } from "chai";
-import { BigNumber, Contract, Signature, Wallet } from "ethers";
+import { BigNumber, Wallet } from "ethers";
 import {
   formatBytes32String,
+  hexConcat,
   hexlify,
-  splitSignature,
   zeroPad,
 } from "ethers/lib/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 import { expandTo18Decimals, uint256Max, zeroAddress } from "./utilities";
+
+import { LnErc20Bridge, MockERC20, MockWormhole } from "../typechain";
 
 use(waffle.solidity);
 
@@ -18,17 +20,21 @@ const TOKEN_LOCK_TYPE_MINT_BURN: number = 2;
 describe("LnErc20Bridge", function () {
   let deployer: SignerWithAddress,
     admin: SignerWithAddress,
-    alice: SignerWithAddress,
-    bob: SignerWithAddress,
-    relayer: Wallet;
+    alice: SignerWithAddress;
 
-  let lina: Contract, lusd: Contract, lnErc20Bridge: Contract;
+  let lina: MockERC20,
+    lusd: MockERC20,
+    wormhole: MockWormhole,
+    lnErc20Bridge: LnErc20Bridge;
 
   let currentChainId: BigNumber,
-    mockChainId: BigNumber = BigNumber.from(9999);
+    mockChainId: BigNumber = BigNumber.from(9999),
+    mockWormholeNetworkId: BigNumber = BigNumber.from(5);
 
-  const createSignature = async (
-    signer: Wallet,
+  const mockBridgeAddress: string =
+    "0x000000000000000000000000000000000000dead";
+
+  const generatePayload = (
     srcChainId: BigNumber,
     destChainId: BigNumber,
     depositId: BigNumber,
@@ -36,46 +42,23 @@ describe("LnErc20Bridge", function () {
     recipient: string,
     currency: string,
     amount: BigNumber
-  ): Promise<string> => {
-    const domain = {
-      name: "Linear",
-      version: "1",
-      chainId: (await ethers.provider.getNetwork()).chainId,
-      verifyingContract: lnErc20Bridge.address,
-    };
-
-    const types = {
-      Deposit: [
-        { name: "srcChainId", type: "uint256" },
-        { name: "destChainId", type: "uint256" },
-        { name: "depositId", type: "uint256" },
-        { name: "depositor", type: "bytes32" },
-        { name: "recipient", type: "bytes32" },
-        { name: "currency", type: "bytes32" },
-        { name: "amount", type: "uint256" },
-      ],
-    };
-
-    const value = {
-      srcChainId,
-      destChainId,
-      depositId,
-      depositor,
-      recipient,
-      currency,
-      amount,
-    };
-
-    const signatureHex = await signer._signTypedData(domain, types, value);
-
-    return signatureHex;
+  ): string => {
+    return hexConcat([
+      hexlify(zeroPad(srcChainId.toHexString(), 32)),
+      hexlify(zeroPad(destChainId.toHexString(), 32)),
+      hexlify(zeroPad(depositId.toHexString(), 32)),
+      hexlify(zeroPad(depositor, 32)),
+      hexlify(zeroPad(recipient, 32)),
+      formatBytes32String(currency),
+      hexlify(zeroPad(amount.toHexString(), 32)),
+    ]);
   };
 
   beforeEach(async function () {
-    [deployer, admin, alice, bob] = await ethers.getSigners();
-    relayer = Wallet.createRandom();
+    [deployer, admin, alice] = await ethers.getSigners();
 
     const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const MockWormhole = await ethers.getContractFactory("MockWormhole");
     const LnErc20Bridge = await ethers.getContractFactory("LnErc20Bridge");
 
     currentChainId = BigNumber.from(
@@ -91,9 +74,10 @@ describe("LnErc20Bridge", function () {
       "lUSD" // _symbol
     );
 
+    wormhole = await MockWormhole.deploy();
+
     lnErc20Bridge = await LnErc20Bridge.deploy();
     await lnErc20Bridge.connect(deployer).__LnErc20Bridge_init(
-      relayer.address, // _relayer
       admin.address // _admin
     );
 
@@ -128,284 +112,350 @@ describe("LnErc20Bridge", function () {
       formatBytes32String("lUSD"), // tokenKey
       mockChainId // chainId
     );
+
+    await lnErc20Bridge.connect(admin).setUpWormhole(
+      wormhole.address, // _coreContract
+      15 // _consistencyLevel
+    );
+    await lnErc20Bridge.connect(admin).setBridgeAddressForChain(
+      mockChainId, // chainId
+      mockBridgeAddress // bridgeAddress
+    );
   });
 
-  it("cannot deposit with unsupported token", async () => {
-    await expect(
-      lnErc20Bridge.connect(alice).deposit(
-        formatBytes32String("NOTFOUND"), // token
-        expandTo18Decimals(1_000), // amount
-        mockChainId, // destChainId
-        hexlify(zeroPad(alice.address, 32)) // recipient
+  describe("Deposit", function () {
+    it("cannot deposit with unsupported token", async () => {
+      await expect(
+        lnErc20Bridge.connect(alice).deposit(
+          formatBytes32String("NOTFOUND"), // token
+          expandTo18Decimals(1_000), // amount
+          mockChainId, // destChainId
+          hexlify(zeroPad(alice.address, 32)) // recipient
+        )
+      ).to.revertedWith("LnErc20Bridge: token not found");
+    });
+
+    it("cannot deposit for unsupported chain", async () => {
+      await expect(
+        lnErc20Bridge.connect(alice).deposit(
+          formatBytes32String("LINA"), // token
+          expandTo18Decimals(1_000), // amount
+          BigNumber.from(8888), // destChainId
+          hexlify(zeroPad(alice.address, 32)) // recipient
+        )
+      ).to.revertedWith("LnErc20Bridge: token not supported on chain");
+    });
+
+    it("token tranferred on deposit of token in transfer mode", async () => {
+      await expect(
+        lnErc20Bridge.connect(alice).deposit(
+          formatBytes32String("LINA"), // token
+          expandTo18Decimals(1_000), // amount
+          mockChainId, // destChainId
+          hexlify(zeroPad(alice.address, 32)) // recipient
+        )
       )
-    ).to.revertedWith("LnErc20Bridge: token not found");
-  });
+        .to.emit(lina, "Transfer")
+        .withArgs(
+          alice.address,
+          lnErc20Bridge.address,
+          expandTo18Decimals(1_000)
+        )
+        .and.emit(lnErc20Bridge, "TokenDeposited")
+        .withArgs(
+          currentChainId, // srcChainId
+          mockChainId, // destChainId
+          1, // depositId
+          hexlify(zeroPad(alice.address, 32)), // depositor
+          hexlify(zeroPad(alice.address, 32)), // recipient
+          formatBytes32String("LINA"), // currency
+          expandTo18Decimals(1_000), // amount
+          0 // wormholeSequence
+        );
 
-  it("cannot deposit for unsupported chain", async () => {
-    await expect(
-      lnErc20Bridge.connect(alice).deposit(
+      expect(await lina.balanceOf(alice.address)).to.equal(
+        expandTo18Decimals(999_000)
+      );
+      expect(await lina.balanceOf(lnErc20Bridge.address)).to.equal(
+        expandTo18Decimals(1_001_000)
+      );
+    });
+
+    it("token burnt on deposit of token in mint/burn mode", async () => {
+      await expect(
+        lnErc20Bridge.connect(alice).deposit(
+          formatBytes32String("lUSD"), // token
+          expandTo18Decimals(1_000), // amount
+          mockChainId, // destChainId
+          hexlify(zeroPad(alice.address, 32)) // recipient
+        )
+      )
+        .to.emit(lusd, "Transfer")
+        .withArgs(alice.address, zeroAddress, expandTo18Decimals(1_000))
+        .and.emit(lnErc20Bridge, "TokenDeposited")
+        .withArgs(
+          currentChainId, // srcChainId
+          mockChainId, // destChainId
+          1, // depositId
+          hexlify(zeroPad(alice.address, 32)), // depositor
+          hexlify(zeroPad(alice.address, 32)), // recipient
+          formatBytes32String("lUSD"), // currency
+          expandTo18Decimals(1_000), // amount
+          0 // wormholeSequence
+        );
+
+      expect(await lusd.balanceOf(alice.address)).to.equal(
+        expandTo18Decimals(999_000)
+      );
+      expect(await lusd.balanceOf(lnErc20Bridge.address)).to.equal(0);
+    });
+
+    it("depositId should increment on each deposit", async () => {
+      expect(await lnErc20Bridge.depositCount()).to.equal(0);
+
+      await expect(
+        lnErc20Bridge.connect(alice).deposit(
+          formatBytes32String("lUSD"), // token
+          expandTo18Decimals(1_000), // amount
+          mockChainId, // destChainId
+          hexlify(zeroPad(alice.address, 32)) // recipient
+        )
+      )
+        .to.emit(lnErc20Bridge, "TokenDeposited")
+        .withArgs(
+          currentChainId, // srcChainId
+          mockChainId, // destChainId
+          1, // depositId
+          hexlify(zeroPad(alice.address, 32)), // depositor
+          hexlify(zeroPad(alice.address, 32)), // recipient
+          formatBytes32String("lUSD"), // currency
+          expandTo18Decimals(1_000), // amount
+          0 // wormholeSequence
+        );
+
+      expect(await lnErc20Bridge.depositCount()).to.equal(1);
+
+      await expect(
+        lnErc20Bridge.connect(alice).deposit(
+          formatBytes32String("lUSD"), // token
+          expandTo18Decimals(1_000), // amount
+          mockChainId, // destChainId
+          hexlify(zeroPad(alice.address, 32)) // recipient
+        )
+      )
+        .to.emit(lnErc20Bridge, "TokenDeposited")
+        .withArgs(
+          currentChainId, // srcChainId
+          mockChainId, // destChainId
+          2, // depositId
+          hexlify(zeroPad(alice.address, 32)), // depositor
+          hexlify(zeroPad(alice.address, 32)), // recipient
+          formatBytes32String("lUSD"), // currency
+          expandTo18Decimals(1_000), // amount
+          1 // wormholeSequence
+        );
+
+      expect(await lnErc20Bridge.depositCount()).to.equal(2);
+    });
+
+    it("should emit expected payload on deposit", async () => {
+      await lnErc20Bridge.connect(alice).deposit(
         formatBytes32String("LINA"), // token
         expandTo18Decimals(1_000), // amount
-        BigNumber.from(8888), // destChainId
-        hexlify(zeroPad(alice.address, 32)) // recipient
-      )
-    ).to.revertedWith("LnErc20Bridge: token not supported on chain");
-  });
-
-  it("token tranferred on deposit of token in transfer mode", async () => {
-    await expect(
-      lnErc20Bridge.connect(alice).deposit(
-        formatBytes32String("LINA"), // token
-        expandTo18Decimals(1_000), // amount
         mockChainId, // destChainId
         hexlify(zeroPad(alice.address, 32)) // recipient
-      )
-    )
-      .to.emit(lina, "Transfer")
-      .withArgs(alice.address, lnErc20Bridge.address, expandTo18Decimals(1_000))
-      .and.emit(lnErc20Bridge, "TokenDeposited")
-      .withArgs(
+      );
+
+      const payload = await wormhole.lastPayload();
+      const expectedPayload = generatePayload(
         currentChainId, // srcChainId
         mockChainId, // destChainId
-        1, // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("LINA"), // currency
+        BigNumber.from(1), // depositId
+        alice.address, // depositor
+        alice.address, // recipient
+        "LINA", // currency
         expandTo18Decimals(1_000) // amount
       );
 
-    expect(await lina.balanceOf(alice.address)).to.equal(
-      expandTo18Decimals(999_000)
-    );
-    expect(await lina.balanceOf(lnErc20Bridge.address)).to.equal(
-      expandTo18Decimals(1_001_000)
-    );
+      expect(payload).to.equal(expectedPayload);
+    });
   });
 
-  it("token burnt on deposit of token in mint/burn mode", async () => {
-    await expect(
-      lnErc20Bridge.connect(alice).deposit(
-        formatBytes32String("lUSD"), // token
-        expandTo18Decimals(1_000), // amount
-        mockChainId, // destChainId
-        hexlify(zeroPad(alice.address, 32)) // recipient
-      )
-    )
-      .to.emit(lusd, "Transfer")
-      .withArgs(alice.address, zeroAddress, expandTo18Decimals(1_000))
-      .and.emit(lnErc20Bridge, "TokenDeposited")
-      .withArgs(
-        currentChainId, // srcChainId
-        mockChainId, // destChainId
-        1, // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("lUSD"), // currency
-        expandTo18Decimals(1_000) // amount
-      );
+  describe("Withdrawal", function () {
+    let payload: string;
 
-    expect(await lusd.balanceOf(alice.address)).to.equal(
-      expandTo18Decimals(999_000)
-    );
-    expect(await lusd.balanceOf(lnErc20Bridge.address)).to.equal(0);
-  });
+    // This doesn't matter as it's discarded by the mock Wormhole contract.
+    const mockWormholeMessage: string = "0x1234";
 
-  it("cannot withdraw with invalid signature", async () => {
-    // Signature with wrong depositId
-    const signature = await createSignature(
-      relayer, // signer
-      mockChainId, // srcChainId
-      currentChainId, // destChainId
-      BigNumber.from(999), // depositId
-      hexlify(zeroPad(alice.address, 32)), // depositor
-      hexlify(zeroPad(alice.address, 32)), // recipient
-      formatBytes32String("LINA"), // currency
-      expandTo18Decimals(1_000) // amount
-    );
-
-    await expect(
-      lnErc20Bridge.connect(alice).withdraw(
+    beforeEach(async function () {
+      // Happy case payload
+      payload = generatePayload(
         mockChainId, // srcChainId
         currentChainId, // destChainId
         BigNumber.from(1), // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("LINA"), // currency
-        expandTo18Decimals(1000), // amount
-        signature // signature
+        alice.address, // depositor
+        alice.address, // recipient
+        "LINA", // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+      await wormhole.connect(admin).setVmToReturn(
+        mockWormholeNetworkId, // emitterChainId
+        hexlify(zeroPad(mockBridgeAddress, 32)), // emitterAddress,
+        payload // payload
+      );
+
+      await lnErc20Bridge.connect(admin).setWormholeNetworkIdForChain(
+        mockChainId, // chainId
+        mockWormholeNetworkId // wormholeNetworkId
+      );
+    });
+
+    it("cannot withdraw if wormhole verification fails", async () => {
+      await wormhole.connect(admin).setShouldFailVerification(true);
+
+      await expect(
+        lnErc20Bridge.connect(alice).withdraw(
+          mockWormholeMessage // encodedWormholeMessage
+        )
+      ).to.revertedWith("LnErc20Bridge: wormhole message verification failed");
+    });
+
+    it("cannot withdraw if emitted from wrong network", async () => {
+      await wormhole.connect(admin).setVmToReturn(
+        mockWormholeNetworkId.add(1), // emitterChainId
+        hexlify(zeroPad(mockBridgeAddress, 32)), // emitterAddress,
+        payload // payload
+      );
+
+      await expect(
+        lnErc20Bridge.connect(alice).withdraw(
+          mockWormholeMessage // encodedWormholeMessage
+        )
+      ).to.revertedWith("LnErc20Bridge: network id mismatch");
+    });
+
+    it("cannot withdraw if emitted from wrong address", async () => {
+      await wormhole.connect(admin).setVmToReturn(
+        mockWormholeNetworkId, // emitterChainId
+        hexlify(zeroPad(mockBridgeAddress.replace("e", "a"), 32)), // emitterAddress,
+        payload // payload
+      );
+
+      await expect(
+        lnErc20Bridge.connect(alice).withdraw(
+          mockWormholeMessage // encodedWormholeMessage
+        )
+      ).to.revertedWith("LnErc20Bridge: emitter mismatch");
+    });
+
+    it("cannot withdraw if payload dest chain is wrong", async () => {
+      payload = generatePayload(
+        mockChainId, // srcChainId
+        currentChainId.add(1), // destChainId
+        BigNumber.from(1), // depositId
+        alice.address, // depositor
+        alice.address, // recipient
+        "LINA", // currency
+        expandTo18Decimals(1_000) // amount
+      );
+
+      await wormhole.connect(admin).setVmToReturn(
+        mockWormholeNetworkId, // emitterChainId
+        hexlify(zeroPad(mockBridgeAddress, 32)), // emitterAddress,
+        payload // payload
+      );
+
+      await expect(
+        lnErc20Bridge.connect(alice).withdraw(
+          mockWormholeMessage // encodedWormholeMessage
+        )
+      ).to.revertedWith("LnErc20Bridge: wrong chain");
+    });
+
+    it("token tranferred on withdrawal of token in transfer mode", async () => {
+      await expect(
+        lnErc20Bridge.connect(alice).withdraw(
+          mockWormholeMessage // encodedWormholeMessage
+        )
       )
-    ).to.revertedWith("LnErc20Bridge: invalid signature");
-  });
+        .to.emit(lina, "Transfer")
+        .withArgs(
+          lnErc20Bridge.address,
+          alice.address,
+          expandTo18Decimals(1_000)
+        )
+        .and.emit(lnErc20Bridge, "TokenWithdrawn")
+        .withArgs(
+          mockChainId, // srcChainId
+          currentChainId, // destChainId
+          1, // depositId
+          hexlify(zeroPad(alice.address, 32)), // depositor
+          hexlify(zeroPad(alice.address, 32)), // recipient
+          formatBytes32String("LINA"), // currency
+          expandTo18Decimals(1_000) // amount
+        );
 
-  it("token tranferred on withdrawal of token in transfer mode", async () => {
-    const signature = await createSignature(
-      relayer, // signer
-      mockChainId, // srcChainId
-      currentChainId, // destChainId
-      BigNumber.from(1), // depositId
-      hexlify(zeroPad(alice.address, 32)), // depositor
-      hexlify(zeroPad(alice.address, 32)), // recipient
-      formatBytes32String("LINA"), // currency
-      expandTo18Decimals(1_000) // amount
-    );
+      expect(await lina.balanceOf(alice.address)).to.equal(
+        expandTo18Decimals(1_001_000)
+      );
+      expect(await lina.balanceOf(lnErc20Bridge.address)).to.equal(
+        expandTo18Decimals(999_000)
+      );
+    });
 
-    await expect(
-      lnErc20Bridge.connect(alice).withdraw(
+    it("token minted on withdrawal of token in mint/burn mode", async () => {
+      payload = generatePayload(
         mockChainId, // srcChainId
         currentChainId, // destChainId
         BigNumber.from(1), // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("LINA"), // currency
-        expandTo18Decimals(1000), // amount
-        signature // signature
-      )
-    )
-      .to.emit(lina, "Transfer")
-      .withArgs(lnErc20Bridge.address, alice.address, expandTo18Decimals(1_000))
-      .and.emit(lnErc20Bridge, "TokenWithdrawn")
-      .withArgs(
-        mockChainId, // srcChainId
-        currentChainId, // destChainId
-        1, // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("LINA"), // currency
+        alice.address, // depositor
+        alice.address, // recipient
+        "lUSD", // currency
         expandTo18Decimals(1_000) // amount
       );
 
-    expect(await lina.balanceOf(alice.address)).to.equal(
-      expandTo18Decimals(1_001_000)
-    );
-    expect(await lina.balanceOf(lnErc20Bridge.address)).to.equal(
-      expandTo18Decimals(999_000)
-    );
-  });
-
-  it("token minted on withdrawal of token in mint/burn mode", async () => {
-    const signature = await createSignature(
-      relayer, // signer
-      mockChainId, // srcChainId
-      currentChainId, // destChainId
-      BigNumber.from(1), // depositId
-      hexlify(zeroPad(alice.address, 32)), // depositor
-      hexlify(zeroPad(alice.address, 32)), // recipient
-      formatBytes32String("lUSD"), // currency
-      expandTo18Decimals(1_000) // amount
-    );
-
-    await expect(
-      lnErc20Bridge.connect(alice).withdraw(
-        mockChainId, // srcChainId
-        currentChainId, // destChainId
-        BigNumber.from(1), // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("lUSD"), // currency
-        expandTo18Decimals(1000), // amount
-        signature // signature
-      )
-    )
-      .to.emit(lusd, "Transfer")
-      .withArgs(zeroAddress, alice.address, expandTo18Decimals(1_000))
-      .and.emit(lnErc20Bridge, "TokenWithdrawn")
-      .withArgs(
-        mockChainId, // srcChainId
-        currentChainId, // destChainId
-        1, // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("lUSD"), // currency
-        expandTo18Decimals(1_000) // amount
+      await wormhole.connect(admin).setVmToReturn(
+        mockWormholeNetworkId, // emitterChainId
+        hexlify(zeroPad(mockBridgeAddress, 32)), // emitterAddress,
+        payload // payload
       );
 
-    expect(await lusd.balanceOf(alice.address)).to.equal(
-      expandTo18Decimals(1_001_000)
-    );
-    expect(await lusd.balanceOf(lnErc20Bridge.address)).to.equal(0);
-  });
-
-  it("cannot withdraw the same deposit multiple times", async () => {
-    const signature = await createSignature(
-      relayer, // signer
-      mockChainId, // srcChainId
-      currentChainId, // destChainId
-      BigNumber.from(1), // depositId
-      hexlify(zeroPad(alice.address, 32)), // depositor
-      hexlify(zeroPad(alice.address, 32)), // recipient
-      formatBytes32String("LINA"), // currency
-      expandTo18Decimals(1_000) // amount
-    );
-
-    // The first withdrawal is successful
-    await lnErc20Bridge.connect(alice).withdraw(
-      mockChainId, // srcChainId
-      currentChainId, // destChainId
-      BigNumber.from(1), // depositId
-      hexlify(zeroPad(alice.address, 32)), // depositor
-      hexlify(zeroPad(alice.address, 32)), // recipient
-      formatBytes32String("LINA"), // currency
-      expandTo18Decimals(1000), // amount
-      signature // signature
-    );
-
-    await expect(
-      lnErc20Bridge.connect(alice).withdraw(
-        mockChainId, // srcChainId
-        currentChainId, // destChainId
-        BigNumber.from(1), // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("LINA"), // currency
-        expandTo18Decimals(1000), // amount
-        signature // signature
+      await expect(
+        lnErc20Bridge.connect(alice).withdraw(
+          mockWormholeMessage // encodedWormholeMessage
+        )
       )
-    ).to.revertedWith("LnErc20Bridge: already withdrawn");
-  });
+        .to.emit(lusd, "Transfer")
+        .withArgs(zeroAddress, alice.address, expandTo18Decimals(1_000))
+        .and.emit(lnErc20Bridge, "TokenWithdrawn")
+        .withArgs(
+          mockChainId, // srcChainId
+          currentChainId, // destChainId
+          1, // depositId
+          hexlify(zeroPad(alice.address, 32)), // depositor
+          hexlify(zeroPad(alice.address, 32)), // recipient
+          formatBytes32String("lUSD"), // currency
+          expandTo18Decimals(1_000) // amount
+        );
 
-  it("depositId should increment on each deposit", async () => {
-    expect(await lnErc20Bridge.depositCount()).to.equal(0);
+      expect(await lusd.balanceOf(alice.address)).to.equal(
+        expandTo18Decimals(1_001_000)
+      );
+      expect(await lusd.balanceOf(lnErc20Bridge.address)).to.equal(0);
+    });
 
-    await expect(
-      lnErc20Bridge.connect(alice).deposit(
-        formatBytes32String("lUSD"), // token
-        expandTo18Decimals(1_000), // amount
-        mockChainId, // destChainId
-        hexlify(zeroPad(alice.address, 32)) // recipient
-      )
-    )
-      .to.emit(lnErc20Bridge, "TokenDeposited")
-      .withArgs(
-        currentChainId, // srcChainId
-        mockChainId, // destChainId
-        1, // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("lUSD"), // currency
-        expandTo18Decimals(1_000) // amount
+    it("cannot withdraw the same deposit multiple times", async () => {
+      // The first withdrawal is successful
+      await lnErc20Bridge.connect(alice).withdraw(
+        mockWormholeMessage // encodedWormholeMessage
       );
 
-    expect(await lnErc20Bridge.depositCount()).to.equal(1);
-
-    await expect(
-      lnErc20Bridge.connect(alice).deposit(
-        formatBytes32String("lUSD"), // token
-        expandTo18Decimals(1_000), // amount
-        mockChainId, // destChainId
-        hexlify(zeroPad(alice.address, 32)) // recipient
-      )
-    )
-      .to.emit(lnErc20Bridge, "TokenDeposited")
-      .withArgs(
-        currentChainId, // srcChainId
-        mockChainId, // destChainId
-        2, // depositId
-        hexlify(zeroPad(alice.address, 32)), // depositor
-        hexlify(zeroPad(alice.address, 32)), // recipient
-        formatBytes32String("lUSD"), // currency
-        expandTo18Decimals(1_000) // amount
-      );
-
-    expect(await lnErc20Bridge.depositCount()).to.equal(2);
+      await expect(
+        lnErc20Bridge.connect(alice).withdraw(
+          mockWormholeMessage // encodedWormholeMessage
+        )
+      ).to.revertedWith("LnErc20Bridge: already withdrawn");
+    });
   });
 });


### PR DESCRIPTION
`LnErc20Bridge` relies on an off-chain relayer to detect and sign deposits, which is currently a single point of failure and a potential source of security issues. The original idea was to later extend the set of relayers to implement a multi-sig scheme to improve both liveness and security.

However, mature cross-chain messaging solutions exist now and there's little value in reinventing the wheel. This PR changes to use [Wormhole](https://wormhole.com/) instead, removing the need of a relayer altogether.