### PR TITLE
feat: expose reward signer count

### DIFF
--- a/.github/workflows/check-code-format.yml
+++ b/.github/workflows/check-code-format.yml
@@ -21,4 +21,4 @@ jobs:
         run: yarn install
 
       - name: Validate Code Format
-        run: yarn format
+        run: yarn prettier --check .

--- a/contracts/LnRewardSystem.sol
+++ b/contracts/LnRewardSystem.sol
@@ -53,6 +53,10 @@ contract LnRewardSystem is LnAdminUpgradeable {
     uint256 public constant CLAIM_WINDOW_PERIOD_COUNT = 2;
     uint256 public constant STAKING_REWARD_LOCK_PERIOD = 52 weeks;
 
+    function getSignerCount() public view returns (uint256) {
+        return rewardSigners.length;
+    }
+
     function getCurrentPeriodId() public view returns (uint256) {
         require(block.timestamp >= firstPeriodStartTime, "LnRewardSystem: first period not started");
         return (block.timestamp - firstPeriodStartTime) / PERIOD_LENGTH + 1; // No SafeMath needed

--- a/contracts/mock/MockRewardSystem.sol
+++ b/contracts/mock/MockRewardSystem.sol
@@ -48,6 +48,10 @@ contract MockRewardSystem is LnAdminUpgradeable {
     uint256 public constant CLAIM_WINDOW_PERIOD_COUNT = 2;
     uint256 public constant STAKING_REWARD_LOCK_PERIOD = 30 minutes;
 
+    function getSignerCount() public view returns (uint256) {
+        return rewardSigners.length;
+    }
+
     function getCurrentPeriodId() public view returns (uint256) {
         require(block.timestamp >= firstPeriodStartTime, "LnRewardSystem: first period not started");
         return (block.timestamp - firstPeriodStartTime) / PERIOD_LENGTH + 1; // No SafeMath needed

--- a/tests/integration/UnlockReward.spec.ts
+++ b/tests/integration/UnlockReward.spec.ts
@@ -122,8 +122,7 @@ describe("Integration | Unlock Reward", function () {
     ).to.equal(expandTo18Decimals(9_000));
 
     // Fast forward to 1st period end
-    const rewardSystemFirstPeriod =
-      await stack.lnRewardSystem.firstPeriodStartTime();
+    const rewardSystemFirstPeriod = await stack.lnRewardSystem.firstPeriodStartTime();
     await setNextBlockTimestamp(
       ethers.provider,
       DateTime.fromSeconds(parseInt(rewardSystemFirstPeriod.toString())).plus(

--- a/tests/utilities/init.ts
+++ b/tests/utilities/init.ts
@@ -501,9 +501,7 @@ export const deployLinearStack = async (
   const lnRewardSystem = await upgrades.deployProxy(
     LnRewardSystem,
     [
-      (
-        await ethers.provider.getBlock("latest")
-      ).timestamp, // _firstPeriodStartTime
+      (await ethers.provider.getBlock("latest")).timestamp, // _firstPeriodStartTime
       [admin.address, "0xffffffffffffffffffffffffffffffffffffffff"], // _rewardSigners
       lusdToken.address, // _lusdAddress
       lnCollateralSystem.address, // _collateralSystemAddress


### PR DESCRIPTION
This PR exposes the length of the `reardSigners` array to make off-chain queries easier.